### PR TITLE
Bootstrap must-gather project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM quay.io/openshift/origin-must-gather:4.13.0 as builder
+
+FROM quay.io/centos/centos:stream8
+
+RUN dnf update -y && dnf install rsync -y && dnf clean all
+
+COPY --from=builder /usr/bin/oc /usr/bin/oc
+
+# Save original gather script
+COPY --from=builder /usr/bin/gather /usr/bin/gather_original
+
+# Copy all collection scripts to /usr/bin
+COPY collection-scripts/* /usr/bin/
+
+ENTRYPOINT /usr/bin/gather

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+IMAGE_REGISTRY ?= quay.io/openstack-k8s-operators
+IMAGE_TAG ?= latest
+
+check-image: ## Check if the MUST_GATHER_IMAGE variable is set
+ifndef MUST_GATHER_IMAGE
+	$(error MUST_GATHER_IMAGE is not set.)
+endif
+
+build: check-image podman-build podman-push ## Build and push the must-gather image
+
+check: ## Run sanity check against the script collection
+	shellcheck collection-scripts/*
+
+podman-build: check-image ## build the must-gather image
+	podman build -t ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG} .
+
+podman-push: check-image ## push the must-gather image to the image registry
+	podman push ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG}
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+.PHONY: build podman-build podman-push

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
 # openstack-must-gather
 
 OCP must-gather scripts for osp operator logs/data collection.
+
+## Usage
+
+(optional) Build and push the must-gather image to a registry:
+
+```
+git clone ssh://git@github.com/openstack-k8s-operators/openstack-must-gather.git
+cd openstack-must-gather
+IMAGE_TAG=<tag> IMAGE_REGISTRY=<registry> MUST_GATHER_IMAGE=must-gather make
+```
+
+On a machine where you have `oc adm` access, do the following:
+
+```
+oc adm must-gather --image=<registry>/must-gather:<tag>
+```
+
+When generation is finished, you will find the dump in the current directory
+under `must-gather.local.XXXXXXXXXX`.
+
+### Note
+
+If the image is pushed to `quay.io` registry, make sure it's set to `public`,
+otherwise it can't be consumed by the must-gather tool.

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
+declare -a DEFAULT_NAMESPACES=(
+    "openstack"
+    "openstack-operators"
+    "baremetal-operator-system"
+    "openshift-machine-api"
+)
+export DEFAULT_NAMESPACES
+
+METALLB_NAMESPACE=${METALLB_NAMESPACE:-"metallb-system"}
+
+NAMESPACE_PATH=${BASE_COLLECTION_PATH}/namespaces
+export NAMESPACE_PATH
+
+# k8s services that must be gather from the openstack
+# ctlplane namespace
+declare resources=(
+    "services"
+    "routes"
+    "daemonset"
+    "replicaset"
+    "deployments"
+    "statefulset"
+    "buildconfig"
+    "jobs"
+)
+export resources
+
+# list of osp services that might be present in the ctlplane
+declare -a OSP_SERVICES=(
+    "keystone"
+    "mariadb"
+    "glance"
+    "neutron"
+    "rabbitmq"
+    "manila"
+    "cinder"
+    "nova"
+    "horizon"
+    "ironic"
+    "telemetry"
+    "heat"
+    "octavia"
+    "placement"
+    "neutron"
+    "swift"
+    "ovn"
+    "ovs"
+    "designate"
+    "barbican"
+    "rabbitmq"
+    "dataplane"
+)
+export OSP_SERVICES
+
+
+WEBHOOKS_COLLECTION_PATH=${BASE_COLLECTION_PATH}/webhooks
+export WEBHOOKS_COLLECTION_PATH
+
+# if a namespace doesn't exist, we don't gather resources
+function check_namespace {
+    local namespace="$1"
+    if /usr/bin/oc get project "$namespace" > /dev/null 2>&1; then
+        return 0
+    fi
+    return 1
+}
+
+# for each resource passed as input, we gather the related
+# info in a dedicated directory within the namespace tree
+function get_resources {
+    local resource="$1"
+    local NS="$2"
+    mkdir -p "${NAMESPACE_PATH}"/"$NS"/"$resource"
+    for res in $(oc -n "$NS" get "$resource" -o custom-columns=":metadata.name"); do
+        echo "Dump $resource: $res";
+        /usr/bin/oc -n "$NS" get "$resource" "$res" > "${NAMESPACE_PATH}"/"$NS"/"$resource"/"$res".yaml
+    done
+}

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck disable=SC1091
+source "${DIR_NAME}/common.sh"
+
+# get apiservices
+/usr/bin/gather_apiservices
+
+# get CRDs
+/usr/bin/gather_crds
+
+# get CRs
+/usr/bin/gather_crs
+
+# get webhooks
+/usr/bin/gather_webhooks
+
+for NS in "${DEFAULT_NAMESPACES[@]}"; do
+    # get Services Config (CM)
+    /usr/bin/gather_services_cm "$NS"
+    # get subscriptions / installplans / packagemanifests / CSVs
+    /usr/bin/gather_sub "$NS"
+    # get routes, services, jobs, deployments
+    # daemonsets, statefulsets, replicasets,
+    # pods (describe and get logs)
+    /usr/bin/gather_ctlplane_resources "$NS"
+done
+
+# get network related resources (nncp, ipaddresspool, l2advertisement)
+/usr/bin/gather_network
+
+# get SVC status (inspect ctlplane)
+/usr/bin/gather_services_status
+
+# TODO:
+# - Get secrets and mask sensitive data

--- a/collection-scripts/gather_apiservices
+++ b/collection-scripts/gather_apiservices
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# load shared functions and data
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck disable=SC1091
+source "${DIR_NAME}/common.sh"
+
+# Resource list
+resources=()
+
+for i in $(/usr/bin/oc get apiservices --all-namespaces | grep openstack.org | awk '{ print $1 }')
+do
+  resources+=("$i")
+done
+
+for resource in "${resources[@]}"; do
+  mkdir -p "$BASE_COLLECTION_PATH"/apiservices/
+  /usr/bin/oc get apiservice "${resource}" -o yaml > "${BASE_COLLECTION_PATH}/apiservices/${resource}.yaml"
+done
+
+exit 0

--- a/collection-scripts/gather_crds
+++ b/collection-scripts/gather_crds
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Resource list
+resources=()
+
+for i in $(/usr/bin/oc get crd | grep openstack.org | awk '{print $1}')
+do
+  resources+=("crd/$i")
+done
+
+# Run the collection of resources using must-gather
+for resource in "${resources[@]}"; do
+  /usr/bin/oc adm inspect --dest-dir must-gather "${resource}"
+done
+
+exit 0

--- a/collection-scripts/gather_crs
+++ b/collection-scripts/gather_crs
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck disable=SC1091
+source "${DIR_NAME}/common.sh"
+
+# Resource list
+resources=()
+
+for i in $(/usr/bin/oc get crd | grep openstack.org | awk '{print $1}')
+do
+  resources+=("$i")
+done
+
+# we use nested loops to nicely output objects partitioned per namespace, kind
+for resource in "${resources[@]}"; do
+  /usr/bin/oc get "${resource}" --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers 2> /dev/null | \
+  while read -r ocresource; do
+    ocobject=$(echo "$ocresource" | awk '{print $1}')
+    ocproject=$(echo "$ocresource" | awk '{print $2}')
+    if [ -z "${ocproject}" ]||[ "${ocproject}" == "<none>" ]; then
+      object_collection_path=${BASE_COLLECTION_PATH}/cluster-scoped-resources/${resource}
+      mkdir -p "${object_collection_path}"
+      /usr/bin/oc get "${resource}" -o yaml "${ocobject}" > "${object_collection_path}/${ocobject}.yaml"
+    else
+      object_collection_path=${BASE_COLLECTION_PATH}/namespaces/${ocproject}/crs/${resource}
+      mkdir -p "${object_collection_path}"
+      /usr/bin/oc get "${resource}" -n "${ocproject}" -o yaml "${ocobject}" > "${object_collection_path}/${ocobject}.yaml"
+    fi
+  done
+done
+
+exit 0

--- a/collection-scripts/gather_ctlplane_resources
+++ b/collection-scripts/gather_ctlplane_resources
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# load shared functions and data
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck disable=SC1091
+source "${DIR_NAME}/common.sh"
+
+NS="$1"
+if [ -z "$NS" ]; then
+    echo "No namespace passed, using the default one"
+    NS=openstack
+fi
+
+# Only get resources if the namespace exists
+if ! check_namespace "${NS}"; then
+    exit 0
+fi
+
+# Get the view of the current namespace related resources, including pods
+mkdir -p "${NAMESPACE_PATH}"/"${NS}"
+/usr/bin/oc -n "${NS}" get all > "${NAMESPACE_PATH}"/"${NS}"/all_resources.log
+/usr/bin/oc -n "${NS}" get events > "${NAMESPACE_PATH}"/"${NS}"/events.log
+/usr/bin/oc -n "${NS}" get pvc > "${NAMESPACE_PATH}"/"${NS}"/pvc.log
+
+# Get pods and the associated logs
+for p in $(oc -n "$NS" get pods -o custom-columns=":metadata.name"); do
+    echo "Dump logs for pod: $p";
+    mkdir -p "${NAMESPACE_PATH}"/"$NS"/pods/"$p"/logs
+    # describe pod
+    /usr/bin/oc -n "$NS" describe pod "$p" > "${NAMESPACE_PATH}"/"$NS"/pods/"$p"/"$p"-describe.log
+    # get logs
+    /usr/bin/oc -n "$NS" logs --prefix=true --all-containers=true "$p" > "${NAMESPACE_PATH}"/"$NS"/pods/"$p"/logs/"$p".log;
+    # dump --previous logs for all the terminated containers of the pod
+    cur=$(/usr/bin/oc -n "$NS" get pods "$p"  -o jsonpath="{.status.containerStatuses[*].lastState.terminated}")
+    if [[ -n "$cur" ]]; then
+        /usr/bin/oc -n "$NS" logs --prefix=true --previous "$p" > "${NAMESPACE_PATH}"/"$NS"/pods/"$p"/logs/"$p"-previous.log;
+    fi
+done
+
+# get the required resources
+# shellcheck disable=SC2154
+for r in "${resources[@]}"; do
+    get_resources "$r" "$NS"
+done
+
+exit 0

--- a/collection-scripts/gather_network
+++ b/collection-scripts/gather_network
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck disable=SC1091
+source "${DIR_NAME}/common.sh"
+
+# get nncp
+mkdir -p "${BASE_COLLECTION_PATH}/network/nncp"
+for iface in $(oc -n "${METALLB_NAMESPACE}" get nncp -o custom-columns=":metadata.name"); do
+    /usr/bin/oc -n "${METALLB_NAMESPACE}" get nncp "$iface" -o yaml > "${BASE_COLLECTION_PATH}/network/nncp/$iface.log";
+done
+
+# get ipaddresspools
+mkdir -p "${BASE_COLLECTION_PATH}/network/ipaddresspools"
+for ipadd in $(oc -n "${METALLB_NAMESPACE}" get ipaddresspools -o custom-columns=":metadata.name"); do
+    /usr/bin/oc -n "${METALLB_NAMESPACE}" get ipaddresspools "$ipadd" -o yaml > "${BASE_COLLECTION_PATH}/network/ipaddresspools/$ipadd.log";
+done
+
+# get l2advertisement
+/usr/bin/oc -n "${METALLB_NAMESPACE}" get l2advertisement -o yaml >> "${BASE_COLLECTION_PATH}/network/l2advertisement.log"
+
+exit 0

--- a/collection-scripts/gather_services_cm
+++ b/collection-scripts/gather_services_cm
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# load shared functions and data
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck disable=SC1091
+source "${DIR_NAME}/common.sh"
+
+NS="$1"
+if [ -z "$NS" ]; then
+    echo "No namespace passed, using the default one"
+    NS=openstack
+fi
+
+# Only get resources if the namespace exists
+if ! check_namespace "${NS}"; then
+    exit 0
+fi
+
+get_cm() {
+        local service="$1"
+        mkdir -p "$NAMESPACE_PATH"/"$NS"/configmaps
+        CMS=$(/usr/bin/oc -n "$NS" get cm | grep -i "$service" | awk '{print $1}')
+        # shellcheck disable=SC2068
+        for cm in ${CMS[@]}; do
+                echo "Extracting ConfigMap: $cm"
+                /usr/bin/oc -n "$NS" get cm "$cm" --output yaml > "$NAMESPACE_PATH"/"$NS"/configmaps/"$cm".yaml
+        done
+}
+
+for svc in "${OSP_SERVICES[@]}"; do
+    get_cm "$svc"
+done
+
+exit 0

--- a/collection-scripts/gather_services_status
+++ b/collection-scripts/gather_services_status
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck disable=SC1091
+source "${DIR_NAME}/common.sh"
+SERVICES=("openstack")
+
+alias os="/usr/bin/oc -n openstack rsh openstackclient openstack "
+
+get_status() {
+    service="$1"
+    case "${service}" in
+    "openstack") get_openstack_status
+                 ;;
+    "manila") get_manila_status
+              ;;
+    *) exit 0
+    esac
+}
+
+get_openstack_status() {
+        mkdir -p "$BASE_COLLECTION_PATH"/ctlplane
+        ${BASH_ALIASES[os]} endpoint list > "$BASE_COLLECTION_PATH"/ctlplane/endpoints
+        ${BASH_ALIASES[os]} service list > "$BASE_COLLECTION_PATH"/ctlplane/services
+        ${BASH_ALIASES[os]} compute service list > "$BASE_COLLECTION_PATH"/ctlplane/compute_service_list
+        ${BASH_ALIASES[os]} network agent list > "$BASE_COLLECTION_PATH"/ctlplane/network_agent_list
+}
+
+get_manila_status() {
+    ${BASH_ALIASES[os]} share service list > "$BASE_COLLECTION_PATH"/manila/service_list
+    ${BASH_ALIASES[os]} share type list > "$BASE_COLLECTION_PATH"/manila/share_types
+    ${BASH_ALIASES[os]} share pool list --detail > "$BASE_COLLECTION_PATH"/manila/pool_list
+}
+
+for svc in "${SERVICES[@]}"; do
+    get_status "$svc"
+done
+
+exit 0

--- a/collection-scripts/gather_sub
+++ b/collection-scripts/gather_sub
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck disable=SC1091
+source "${DIR_NAME}/common.sh"
+
+IFS=$'\n'
+
+# Collect packagemanifests that are global
+mkdir -p "${BASE_COLLECTION_PATH}"
+/usr/bin/oc get packagemanifest -o yaml >>"${BASE_COLLECTION_PATH}/packagemanifests"
+
+NS="$1"
+if [ -z "$NS" ]; then
+    echo "No namespace passed, using the default one"
+    NS=openstack
+fi
+
+# Only get resources if the namespace exists
+if ! check_namespace "${NS}"; then
+    exit 0
+fi
+
+# Get CSVs for the current namespace and collect them in ${BASE_COLLECTION_PATH}/csv
+mkdir -p "${BASE_COLLECTION_PATH}/csv/"
+for service in $(oc -n "${NS}" get csv -o=custom-columns=NAME:.metadata.name --no-headers)
+do
+    /usr/bin/oc -n "${NS}" get csv "$service" -o yaml >> "${BASE_COLLECTION_PATH}/csv/$service"
+done
+
+mkdir -p "${NAMESPACE_PATH}/${NS}/subscriptions/"
+for service in $(oc get subscriptions -n "$NS" -o=custom-columns=NAME:.metadata.name --no-headers)
+do
+    /usr/bin/oc get subscription "$service" -n "$NS" -o yaml >> "${NAMESPACE_PATH}/${NS}/subscriptions/$service"
+done
+
+mkdir -p "${NAMESPACE_PATH}/${NS}/installplans/"
+for service in $(oc get installplan -n "$NS" -o=custom-columns=NAME:.metadata.name --no-headers)
+do
+    /usr/bin/oc get installplan "$service" -n "$NS" -o yaml >> "${NAMESPACE_PATH}/${NS}/installplans/$service"
+done
+
+exit 0

--- a/collection-scripts/gather_webhooks
+++ b/collection-scripts/gather_webhooks
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+mkdir -p "${WEBHOOKS_COLLECTION_PATH}/validating"
+for resource in $(/usr/bin/oc get validatingwebhookconfiguration -o custom-columns=NAME:.metadata.name --no-headers); do
+  /usr/bin/oc get validatingwebhookconfiguration "${resource}" -o yaml > "${WEBHOOKS_COLLECTION_PATH}/validating/${resource}.yaml"
+done
+
+mkdir -p "${WEBHOOKS_COLLECTION_PATH}/mutating"
+for resource in $(/usr/bin/oc get mutatingwebhookconfiguration -o custom-columns=NAME:.metadata.name --no-headers); do
+  /usr/bin/oc get mutatingwebhookconfiguration "${resource}" -o yaml | grep -vi cabundle > "${WEBHOOKS_COLLECTION_PATH}/mutating/${resource}.yaml"
+done
+
+exit 0


### PR DESCRIPTION
This patch represent the bootstrap of the must-gather project.
It provides a firs base collection of scripts required in the `NextGen` context.
Starting from the work already done in the director operator [1], the idea is
to collect all the resources required to ease `OpenStack` services troubleshooting
 in the `OpenShift` context.

Follow up patch:
- gather secrets and mask/obfuscate sensitive data