### PR TITLE
Gather secrets for targeted OSP services

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -19,6 +19,8 @@ source "${DIR_NAME}/common.sh"
 for NS in "${DEFAULT_NAMESPACES[@]}"; do
     # get Services Config (CM)
     /usr/bin/gather_services_cm "$NS"
+    # get Services Secrets
+    /usr/bin/gather_secrets "$NS"
     # get subscriptions / installplans / packagemanifests / CSVs
     /usr/bin/gather_sub "$NS"
     # get routes, services, jobs, deployments

--- a/collection-scripts/gather_secrets
+++ b/collection-scripts/gather_secrets
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# load shared functions and data
+DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# shellcheck disable=SC1091
+source "${DIR_NAME}/common.sh"
+
+NS="$1"
+if [ -z "$NS" ]; then
+    echo "No namespace passed, using the default one"
+    NS=openstack
+fi
+
+# Only get resources if the namespace exists
+if ! check_namespace "${NS}"; then
+    exit 0
+fi
+
+# TODO: Get secrets where a must-gather label is set. The following command
+# get everything at the moment. All the retrieved yaml file present the .data
+# section with a base64 encoded value, which represents the whole content of
+# the secret.
+function get_secrets {
+    local service=$1
+    for s in $(/usr/bin/oc -n "$NS" get secrets | grep -vE "(token|dockercfg)" | awk -v s="$service" '$0 ~ s {print $1}'); do
+        mkdir -p "$NAMESPACE_PATH"/"$NS"/secrets/"$service"
+        /usr/bin/oc -n "$NS" get secret "$s" -o yaml > "$NAMESPACE_PATH"/"$NS"/secrets/"$service"/"$s".yaml;
+    done
+}
+
+for service in "${OSP_SERVICES[@]}"; do
+   get_secrets "$service"
+done


### PR DESCRIPTION
This patch introduces the ability to gather secrets for the available namespaces.
We're limiting secrets gather only to the defined OpenStack services, because some components like nova and cinder encode the whole config file in a secrets and don't rely anymore on the initContainer.

We're going to apply masking and obfuscation, as well as improving the gathering flow in a follow up patch.