### PR TITLE
Get neutron status from the existing ctlplane

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,43 @@
 # openstack-must-gather
 
-OCP must-gather scripts for osp operator logs/data collection.
+`must-gather` is a tool built on top of [OpenShift must-gather](https://github.com/openshift/must-gather)
+that provides the scripts for an OpenStack control plane logs and data collection.
 
 ## Usage
+
+```sh
+oc adm must-gather --image=quay.io/openstack-k8s-operators/must-gather
+```
+
+The command above will create a local directory where logs, configs and status
+of the OpenStack control plane services are dumped.
+
+In particular the `openstack-must-gather` will get a dump of:
+- Service logs: Retrieved by the output of the pods (and operators) associated to the deployed
+  services
+- Services config: Retrieved for each component by the deployed `ConfigMaps` and `Secrets`
+- Status of the services deployed in the OpenStack control plane
+- Deployed CRs and CRDs
+- `CSVs`, `pkgmanifests`, `subscriptions`, `installplans`, `operatorgroup`
+- `Pods`, `Deployments`, `Statefulsets`, `ReplicaSets`, `Service`, `Routes`, `ConfigMaps`, (part of / relevant) `Secrets`
+- Network related info (`Metallb` info, `IPAddressPool`, `L2Advertisements`, `NetConfig`, `IPSet`)
+
+## Development
+
+You can build the image locally using the Dockerfile included.
+A `Makefile` is also provided. To use it, you must pass:
+- an image name using the variable `MUST_GATHER_IMAGE`.
+- an image registry using the variable `IMAGE_REGISTRY` (default is [quay.io/openstack-k8s-operators](https://quay.io/openstack-k8s-operators))
+- an image tag using the variable `IMAGE_TAG` (default is `latest`)
+
+The targets for `make` are as follows:
+- `check-image`: Check if the `MUST_GATHER_IMAGE` variable is set
+- `build`: build the image with the supplied name and pushes it
+- `check`: Run sanity check against the script collection
+- `podman-build`: builds the must-gather image
+- `podman-push`:  pushes an already-built `must-gather` image
+
+## Example
 
 (optional) Build and push the must-gather image to a registry:
 

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -35,7 +35,6 @@ declare -a OSP_SERVICES=(
     "keystone"
     "mariadb"
     "glance"
-    "neutron"
     "rabbitmq"
     "manila"
     "cinder"

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -34,6 +34,3 @@ done
 
 # get SVC status (inspect ctlplane)
 /usr/bin/gather_services_status
-
-# TODO:
-# - Get secrets and mask sensitive data

--- a/collection-scripts/gather_services_status
+++ b/collection-scripts/gather_services_status
@@ -3,37 +3,71 @@
 DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # shellcheck disable=SC1091
 source "${DIR_NAME}/common.sh"
-SERVICES=("openstack")
 
 alias os="/usr/bin/oc -n openstack rsh openstackclient openstack "
 
+# For each service passed an input, if the associated entry exists,
+# we can call the related function that processes specific service
+# commands
 get_status() {
     service="$1"
+    echo "Gather ctlplane service info: $service"
     case "${service}" in
-    "openstack") get_openstack_status
-                 ;;
-    "manila") get_manila_status
-              ;;
-    *) exit 0
+    "openstack")
+        get_openstack_status
+        ;;
+    "manila")
+        get_manila_status
+        ;;
+    "neutron")
+        get_neutron_status
+        ;;
+    *) ;;
     esac
 }
 
+# Generic OpenStack cltplane gathering -
 get_openstack_status() {
-        mkdir -p "$BASE_COLLECTION_PATH"/ctlplane
-        ${BASH_ALIASES[os]} endpoint list > "$BASE_COLLECTION_PATH"/ctlplane/endpoints
-        ${BASH_ALIASES[os]} service list > "$BASE_COLLECTION_PATH"/ctlplane/services
-        ${BASH_ALIASES[os]} compute service list > "$BASE_COLLECTION_PATH"/ctlplane/compute_service_list
-        ${BASH_ALIASES[os]} network agent list > "$BASE_COLLECTION_PATH"/ctlplane/network_agent_list
+    mkdir -p "$BASE_COLLECTION_PATH"/ctlplane
+    ${BASH_ALIASES[os]} endpoint list > "$BASE_COLLECTION_PATH"/ctlplane/endpoints
+    ${BASH_ALIASES[os]} service list > "$BASE_COLLECTION_PATH"/ctlplane/services
+    ${BASH_ALIASES[os]} compute service list > "$BASE_COLLECTION_PATH"/ctlplane/compute_service_list
+    ${BASH_ALIASES[os]} network agent list > "$BASE_COLLECTION_PATH"/ctlplane/network_agent_list
 }
 
+# Manila service gathering -
 get_manila_status() {
-    ${BASH_ALIASES[os]} share service list > "$BASE_COLLECTION_PATH"/manila/service_list
-    ${BASH_ALIASES[os]} share type list > "$BASE_COLLECTION_PATH"/manila/share_types
-    ${BASH_ALIASES[os]} share pool list --detail > "$BASE_COLLECTION_PATH"/manila/pool_list
+    local MANILA_PATH="$BASE_COLLECTION_PATH/ctlplane/manila"
+    mkdir -p "$MANILA_PATH"
+    ${BASH_ALIASES[os]} share service list > "$MANILA_PATH"/service_list
+    ${BASH_ALIASES[os]} share type list > "$MANILA_PATH"/share_types
+    ${BASH_ALIASES[os]} share pool list --detail > "$MANILA_PATH"/pool_list
 }
 
-for svc in "${SERVICES[@]}"; do
-    get_status "$svc"
+# Neutron service gathering -
+get_neutron_status() {
+    local NEUTRON_PATH="$BASE_COLLECTION_PATH/ctlplane/neutron"
+    mkdir -p "$NEUTRON_PATH"
+    ${BASH_ALIASES[os]} subnet list > "$NEUTRON_PATH"/subnet_list
+    ${BASH_ALIASES[os]} port list > "$NEUTRON_PATH"/port_list
+    ${BASH_ALIASES[os]} router list > "$NEUTRON_PATH"/router_list
+    ${BASH_ALIASES[os]} network agent list > "$NEUTRON_PATH"/agent_list
+    ${BASH_ALIASES[os]} network list > "$NEUTRON_PATH"/network_list
+    ${BASH_ALIASES[os]} extension list > "$NEUTRON_PATH"/extension_list
+    ${BASH_ALIASES[os]} floating ip list > "$NEUTRON_PATH"/floating_ip_list
+    ${BASH_ALIASES[os]} security group list > "$NEUTRON_PATH"/security_group_list
+}
+
+# first we gather generic status of the openstack ctlplane
+# then we process the existing services (if an associated
+# function has been defined)
+get_status "openstack"
+# get the list of existing ctlplane services (once) and
+# filter the whole list processing only services with an
+# associated function
+services=$(${BASH_ALIASES[os]} service list -c Name -f value)
+for svc in "${OSP_SERVICES[@]}"; do
+    [[ "${services[*]}" =~ ${svc} ]] && get_status "$svc"
 done
 
 exit 0


### PR DESCRIPTION
This patch improves the way we're gathering information from the existing ctlplane services. In particular, for each service it's possible to define an entry in the `get_status()` `switch/case` and point to the implemented service function. As an example, this patch introduces the same commands we're running for neutron through `SOS` reports [1]. 
The output is stored within the `ctlplane/<service>` directory generated by the must-gather tool.

[1] https://github.com/sosreport/sos/blob/main/sos/report/plugins/openstack_neutron.py#L57-L64