### PR TITLE
Gather data from kuttl namespaces

### DIFF
--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -51,7 +51,6 @@ declare -a OSP_SERVICES=(
     "ovs"
     "designate"
     "barbican"
-    "rabbitmq"
     "dataplane"
 )
 export OSP_SERVICES
@@ -78,5 +77,17 @@ function get_resources {
     for res in $(oc -n "$NS" get "$resource" -o custom-columns=":metadata.name"); do
         echo "Dump $resource: $res";
         /usr/bin/oc -n "$NS" get "$resource" "$res" -o yaml > "${NAMESPACE_PATH}"/"$NS"/"$resource"/"$res".yaml
+    done
+}
+
+# Generic function to expand the DEFAULT_NAMESPACES array where we need to
+# check resources.
+# e.g. calling <expand_ns "kuttl"> will grow the DEFAULT_NAMESPACES array
+# adding all kuttl NS that can be found
+function expand_ns {
+    local expandkey="$1"
+    [ -z "$1" ] && return
+    for i in $(oc get project -o=custom-columns=NAME:.metadata.name --no-headers | awk -v k="$expandkey" '$0 ~ k {print $1}'); do
+        DEFAULT_NAMESPACES+=("${i}")
     done
 }

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -16,6 +16,10 @@ source "${DIR_NAME}/common.sh"
 # get webhooks
 /usr/bin/gather_webhooks
 
+# expand the existing NAMESPACES including kuttl (required for OpenStack CI)
+# if exist so we can gather resources about tests
+expand_ns "kuttl"
+
 for NS in "${DEFAULT_NAMESPACES[@]}"; do
     # get Services Config (CM)
     /usr/bin/gather_services_cm "$NS"

--- a/collection-scripts/gather_apiservices
+++ b/collection-scripts/gather_apiservices
@@ -8,7 +8,8 @@ source "${DIR_NAME}/common.sh"
 # Resource list
 resources=()
 
-for i in $(/usr/bin/oc get apiservices --all-namespaces | grep openstack.org | awk '{ print $1 }')
+# explicitly adding rabbitmq in the grep because we rely on the rabbitmq-cluster-operator
+for i in $(/usr/bin/oc get apiservices --all-namespaces | grep -E "(openstack|rabbitmq)\.(org|com)" | awk '{ print $1 }')
 do
   resources+=("$i")
 done

--- a/collection-scripts/gather_crs
+++ b/collection-scripts/gather_crs
@@ -7,7 +7,9 @@ source "${DIR_NAME}/common.sh"
 # Resource list
 resources=()
 
-for i in $(/usr/bin/oc get crd | grep openstack.org | awk '{print $1}')
+# explictly adding rabbit in the grep because it's not part of the openstack
+# umbrella and we rely on the upstream rabbitmq-cluster-operator
+for i in $(/usr/bin/oc get crd | grep -E "(openstack|rabbitmq)\.(org|com)" | awk '{print $1}')
 do
   resources+=("$i")
 done

--- a/collection-scripts/gather_ctlplane_resources
+++ b/collection-scripts/gather_ctlplane_resources
@@ -21,6 +21,7 @@ mkdir -p "${NAMESPACE_PATH}"/"${NS}"
 /usr/bin/oc -n "${NS}" get all > "${NAMESPACE_PATH}"/"${NS}"/all_resources.log
 /usr/bin/oc -n "${NS}" get events > "${NAMESPACE_PATH}"/"${NS}"/events.log
 /usr/bin/oc -n "${NS}" get pvc > "${NAMESPACE_PATH}"/"${NS}"/pvc.log
+/usr/bin/oc -n "${NS}" get nad -o yaml > "${NAMESPACE_PATH}"/"${NS}"/nad.log
 
 # Get pods and the associated logs
 for p in $(oc -n "$NS" get pods -o custom-columns=":metadata.name"); do


### PR DESCRIPTION
This patch introduces a new, generic function to be able to expand the existing `NAMESPACES` related array with an arbitrary number of elements that reflect a certain criteria. In particular, the gather script adds a new line to grow the existing array adding every project that matches with `kuttl`: by doing this we can finally run the regular resource gathering against this set of additional namespaces.