### PR TITLE
Gather NNCE data

### DIFF
--- a/collection-scripts/gather_network
+++ b/collection-scripts/gather_network
@@ -6,8 +6,14 @@ source "${DIR_NAME}/common.sh"
 
 # get nncp
 mkdir -p "${BASE_COLLECTION_PATH}/network/nncp"
-for iface in $(oc -n "${METALLB_NAMESPACE}" get nncp -o custom-columns=":metadata.name"); do
-    /usr/bin/oc -n "${METALLB_NAMESPACE}" get nncp "$iface" -o yaml > "${BASE_COLLECTION_PATH}/network/nncp/$iface.log";
+for iface in $(oc get nncp -o custom-columns=":metadata.name"); do
+    /usr/bin/oc get nncp "$iface" -o yaml > "${BASE_COLLECTION_PATH}/network/nncp/$iface.log";
+done
+
+# get nnce
+mkdir -p "${BASE_COLLECTION_PATH}/network/nnce"
+for iface in $(oc get nnce -o custom-columns=":metadata.name"); do
+    /usr/bin/oc get nnce "$iface" -o yaml > "${BASE_COLLECTION_PATH}/network/nnce/$iface.log";
 done
 
 # get ipaddresspools


### PR DESCRIPTION
Gather the YAMLs for the NNCEs created by the NNCPs, as these are where failures are most explicitly logged when something goes wrong with NNCPs.  Also removes namespacing from NNCP `oc get`, as these are cluster-scoped resources.