### PR TITLE
Get nodes resources from the current OCP deployment

### DIFF
--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -60,6 +60,9 @@ export OSP_SERVICES
 WEBHOOKS_COLLECTION_PATH=${BASE_COLLECTION_PATH}/webhooks
 export WEBHOOKS_COLLECTION_PATH
 
+NODES_COLLECTION_PATH=${BASE_COLLECTION_PATH}/nodes
+export NODES_COLLECTION_PATH
+
 # if a namespace doesn't exist, we don't gather resources
 function check_namespace {
     local namespace="$1"

--- a/collection-scripts/gather_nodes
+++ b/collection-scripts/gather_nodes
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+mkdir -p "${NODES_COLLECTION_PATH}"
+for node in $(/usr/bin/oc get nodes -o custom-columns=NAME:.metadata.name --no-headers); do
+    /usr/bin/oc get nodes "${node}" -o yaml > "${NODES_COLLECTION_PATH}/${node}.yaml"
+done
+
+exit 0

--- a/collection-scripts/gather_run
+++ b/collection-scripts/gather_run
@@ -4,6 +4,9 @@ DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # shellcheck disable=SC1091
 source "${DIR_NAME}/common.sh"
 
+# get nodes information
+/usr/bin/gather_nodes
+
 # get apiservices
 /usr/bin/gather_apiservices
 


### PR DESCRIPTION
This patch adds a `gather_nodes` script that is supposed to inspect the `openshift nodes` resource and dump some useful information. The script can be extended with follow up patches to gather more than just the nodes resources.