### PR TITLE
Add basic github action to perform sanity-check against PRs

### DIFF
--- a/.github/workflows/sanity-check.yaml
+++ b/.github/workflows/sanity-check.yaml
@@ -1,0 +1,25 @@
+name: Sanity Check
+
+on: [push, pull_request]
+
+jobs:
+  make_check:
+    name: check for issues in the collection_scripts
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: sudo apt-get install -y make
+      - name: Install tox and any other packages
+        run: pip install tox
+      - name: Run ShellCheck
+        run: make check
+      - name: Run PyTest
+        run: make pytest

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 build: check-image podman-build podman-push ## Build and push the must-gather image
 
 check: ## Run sanity check against the script collection
-	shellcheck collection-scripts/*
+	shellcheck -e SC2016 -e SC2006 -e SC2140 -e SC2086 collection-scripts/*
 
 pytest: ## Run sanity check against python scripts in pydir
 	tox -c pyscripts/tox.ini


### PR DESCRIPTION
This patch adds a basic github action that can be used to gate patches and perform at least a sanity-check until some CI jobs (Prow based) are setup.