### PR TITLE
Collect Metal3 BareMetalHost CRs

### DIFF
--- a/collection-scripts/gather_crs
+++ b/collection-scripts/gather_crs
@@ -14,6 +14,9 @@ do
   resources+=("$i")
 done
 
+# explicitly adding Metal3 BareMetalHosts
+resources+=("baremetalhosts.metal3.io")
+
 # we use nested loops to nicely output objects partitioned per namespace, kind
 for resource in "${resources[@]}"; do
   /usr/bin/oc get "${resource}" --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers 2> /dev/null | \


### PR DESCRIPTION
I _think_ we're missing `BareMetalHost`s in the gathered CRs, but perhaps we already do this elsewhere.  Anyhow, proposing this just in case.