### PR TITLE
Add owners file to be used by tide

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+  - ci-approvers
+  - mustgather-approvers
+  - openstack-approvers
+
+reviewers:
+  - ci-approvers
+  - mustgather-approvers
+  - openstack-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,16 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
+
+aliases:
+  mustgather-approvers:
+  - fmount
+  - Akrog
+  ci-approvers:
+  - lewisdenny
+  - frenzyfriday
+  - viroel
+  openstack-approvers:
+    - abays
+    - dprince
+    - gibizer
+    - olliewalsh
+    - stuggi


### PR DESCRIPTION
The repo containing the configuration for the Tide auto merging bot reads the owners file in this repository to set who can modify the config after the initial configuration. 