### PR TITLE
Do not redefine the global $resources variable

### DIFF
--- a/collection-scripts/gather_apiservices
+++ b/collection-scripts/gather_apiservices
@@ -7,15 +7,15 @@ if [[ -z "$DIR_NAME" ]]; then
 fi
 
 # Resource list
-resources=()
+apiservices=()
 
 # explicitly adding rabbitmq in the grep because we rely on the rabbitmq-cluster-operator
 for i in $(/usr/bin/oc get apiservices --all-namespaces | grep -E "(openstack|rabbitmq)\.(org|com)" | awk '{ print $1 }')
 do
-  resources+=("$i")
+  apiservices+=("$i")
 done
 
-for resource in "${resources[@]}"; do
+for resource in "${apiservices[@]}"; do
   mkdir -p "$BASE_COLLECTION_PATH"/apiservices/
   run_bg /usr/bin/oc get apiservice "${resource}" -o yaml '>' "${BASE_COLLECTION_PATH}/apiservices/${resource}.yaml"
 done

--- a/collection-scripts/gather_crds
+++ b/collection-scripts/gather_crds
@@ -8,17 +8,19 @@ fi
 
 
 # Resource list
-resources=()
+crds=()
 
 for i in $(/usr/bin/oc get crd | grep openstack.org | awk '{print $1}')
 do
-  resources+=("crd/$i")
+  crds+=("$i")
 done
 
 echo "Gathering CRDs"
+mkdir -p "$BASE_COLLECTION_PATH"/crd
+
 # Run the collection of resources using must-gather
-for resource in "${resources[@]}"; do
-  run_bg /usr/bin/oc adm inspect --dest-dir must-gather "${resource}"
+for resource in "${crds[@]}"; do
+  run_bg /usr/bin/oc get crd "$resource" -o yaml > "${BASE_COLLECTION_PATH}/crd/${resource}.yaml"
 done
 
 [[ $CALLED -eq 1 ]] && wait_bg

--- a/collection-scripts/gather_crs
+++ b/collection-scripts/gather_crs
@@ -8,33 +8,29 @@ if [[ -z "$DIR_NAME" ]]; then
 fi
 
 # Resource list
-resources=()
+crs=()
 
 # explictly adding rabbit in the grep because it's not part of the openstack
 # umbrella and we rely on the upstream rabbitmq-cluster-operator
 for i in $(/usr/bin/oc get crd | grep -E "(openstack|rabbitmq)\.(org|com)" | awk '{print $1}')
 do
-  resources+=("$i")
+  crs+=("$i")
 done
 
 # explicitly adding Metal3 BareMetalHosts
-resources+=("baremetalhosts.metal3.io")
+crs+=("baremetalhosts.metal3.io")
 
 # we use nested loops to nicely output objects partitioned per namespace, kind
 echo "Gathering CRs"
-for resource in "${resources[@]}"; do
-  /usr/bin/oc get "${resource}" --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers 2> /dev/null | \
+for res in "${crs[@]}"; do
+  /usr/bin/oc get "${res}" --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers 2> /dev/null | \
   while read -r ocresource; do
     ocobject=$(echo "$ocresource" | awk '{print $1}')
     ocproject=$(echo "$ocresource" | awk '{print $2}')
-    if [ -z "${ocproject}" ]||[ "${ocproject}" == "<none>" ]; then
-      object_collection_path=${BASE_COLLECTION_PATH}/cluster-scoped-resources/${resource}
+    if [ -n "${ocproject}" ] && [ "${ocproject}" != "<none>" ]; then
+      object_collection_path=${BASE_COLLECTION_PATH}/namespaces/${ocproject}/crs/${res}
       mkdir -p "${object_collection_path}"
-      run_bg /usr/bin/oc get "${resource}" -o yaml "${ocobject}" '>' "${object_collection_path}/${ocobject}.yaml"
-    else
-      object_collection_path=${BASE_COLLECTION_PATH}/namespaces/${ocproject}/crs/${resource}
-      mkdir -p "${object_collection_path}"
-      run_bg /usr/bin/oc get "${resource}" -n "${ocproject}" -o yaml "${ocobject}" '>' "${object_collection_path}/${ocobject}.yaml"
+      run_bg /usr/bin/oc get "${res}" -n "${ocproject}" -o yaml "${ocobject}" '>' "${object_collection_path}/${ocobject}.yaml"
     fi
   done
 done


### PR DESCRIPTION
This patch fixes in the first place the usage of the `resources` variable.
The purpose of this variable is to define a set of `k8s` related services
that should be collected for each `namespace`; for this reason it's
defined in `common.sh` and exported, so it can be used in any script
that is sourced by `gather_run`.
Instead of using the same `$resources` variable that is used a lot in the
collection-scripts, this change customizes the variable name used to collect
`CR(s)` and `apiservices`, and it avoids collisions with other `get_resources`
happening in other `namespaces`.
In addition, this patch fixes the way `CRD(s)` are collected: they are global
and shouldn't be collected `per-namespace`, hence they're now collected
within the `crd/` folder created in the root `must-gather` directory.
