### PR TITLE
Temporary debugging for SOS gathering

### DIFF
--- a/collection-scripts/gather_edpm_sos
+++ b/collection-scripts/gather_edpm_sos
@@ -74,13 +74,14 @@ gather_edpm_sos () {
 
     echo "Retrieving SOS Report for ${node}"
     mkdir -p "${SOS_PATH_NODES}/sosreport-$node"
-    SSH sudo "cat ${TMPDIR}/*.tar.xz" | tar --one-top-level="${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf -
+    SSH sudo "cat ${TMPDIR}/*.tar.xz" | tee "${SOS_PATH_NODES}/sosreport-$node.tar.xz" | tar --one-top-level="${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf -
 
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
         echo "Failed to download and decompress sosreport-$node.tar.xz not deleting file"
         return 1
     fi
+    rm "${SOS_PATH_NODES}/sosreport-$node.tar.xz"
 
     # Ensure write access to the sos reports directories so must-gather rsync doesn't fail
     chmod +w -R "${SOS_PATH_NODES}/sosreport-$node/"

--- a/collection-scripts/gather_sos
+++ b/collection-scripts/gather_sos
@@ -91,13 +91,14 @@ gather_node_sos () {
     echo "Retrieving SOS Report for ${node}"
     mkdir "${SOS_PATH_NODES}/sosreport-$node"
     # Add "--loglevel 6" to help debug in case there's a failure
-    oc debug --loglevel 6 "node/$node" -- cat "/host${TMPDIR}/*.tar.xz" | tar --one-top-level="${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf -
+    oc debug --loglevel 6 "node/$node" -- cat "/host${TMPDIR}/*.tar.xz" | tee "${SOS_PATH_NODES}/sosreport-$node.tar.xz" | tar --one-top-level="${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf -
 
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
         echo "Failed to download and decompress sosreport-$node.tar.xz not deleting file"
         return 1
     fi
+    rm "${SOS_PATH_NODES}/sosreport-$node.tar.xz"
 
     # Ensure write access to the sos reports directories so must-gather rsync doesn't fail
     chmod +w -R "${SOS_PATH_NODES}/sosreport-$node/"

--- a/collection-scripts/gather_sos
+++ b/collection-scripts/gather_sos
@@ -91,7 +91,7 @@ gather_node_sos () {
     echo "Retrieving SOS Report for ${node}"
     mkdir "${SOS_PATH_NODES}/sosreport-$node"
     # Add "--loglevel 6" to help debug in case there's a failure
-    oc debug --loglevel 6 "node/$node" -- cat "/host${TMPDIR}/*.tar.xz" | tee "${SOS_PATH_NODES}/sosreport-$node.tar.xz" | tar --one-top-level="${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf -
+    oc debug --loglevel 6 "node/$node" -- bash -c "cat \"/host${TMPDIR}/\"*.tar.xz" | tee "${SOS_PATH_NODES}/sosreport-$node.tar.xz" | tar --one-top-level="${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf -
 
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
This patch adds a `tee` command to the download and decompression pipe in the gather_sos script. By writing the output of cat and the input of tar into a file we can see what it got on failure.