### PR TITLE
Add ADDITIONAL_NAMESPACES environment variable

### DIFF
--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -13,6 +13,12 @@ declare -a DEFAULT_NAMESPACES=(
 )
 export DEFAULT_NAMESPACES
 
+declare -a ADDITIONAL_NAMESPACES=(
+    "kuttl"
+    "sushy-emulator"
+)
+export ADDITIONAL_NAMESPACES
+
 METALLB_NAMESPACE=${METALLB_NAMESPACE:-"metallb-system"}
 
 NAMESPACE_PATH=${BASE_COLLECTION_PATH}/namespaces

--- a/collection-scripts/gather_run
+++ b/collection-scripts/gather_run
@@ -23,9 +23,11 @@ source "${DIR_NAME}/gather_crs"
 # get webhooks
 source "${DIR_NAME}/gather_webhooks"
 
-# expand the existing NAMESPACES including kuttl (required for OpenStack CI)
-# if exist so we can gather resources about tests
-expand_ns "kuttl"
+# expand the existing NAMESPACES including some relevant for OpenStack CI
+# if they exist we can gather the associated resources and logs
+for ns in "${ADDITIONAL_NAMESPACES[@]}"; do
+    expand_ns "$ns"
+done
 
 # Trigger Guru Meditation Reports so we then have then in the service logs
 source "${DIR_NAME}/gather_trigger_gmr"


### PR DESCRIPTION
We might need to gather logs from more `namespaces` when we execute the `openstack-must-gather` tool in CI.
For this reason this patch introduces an `ADDITIONAL_NAMESPACES` environment variable to collect the list of the namespaces relevant for CI.