### PR TITLE
Add podified-multinode-edpm-deployment-crc zuul job

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,5 +1,5 @@
 - project:
     github-check:
       jobs:
-      - noop
+      - podified-multinode-edpm-deployment-crc
     name: openstack-k8s-operators/openstack-must-gather


### PR DESCRIPTION
This patch replaces the noop job with a real job that deploys
a real environment with a fresh openstack-must-gather image after
https://github.com/openstack-k8s-operators/ci-framework/pull/868 merges