### PR TITLE
Add ability to provide list of sos plugins to openstack-must-gather

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ This is the list of available environmental variables:
 - `SOS_EDPM`: Comma separated list of edpm nodes to gather SOS reports from,
   empty string skips sos report gathering. Accepts keyword all to gather all
   nodes. eg: `edpm-compute-0,edpm-compute-1`
-- `SOS_EDPM_PROFILES`: list of sos report profiles to use. Empty string to run
+- `SOS_EDPM_PROFILES`: List of sos report profiles to use. Empty string to run
   them all. Defaults to: `system,storage,virt`
+- `SOS_EDPM_PLUGINS`: List of sos report plugins to use. This is optional.
 
 ## Development
 

--- a/collection-scripts/gather_edpm_sos
+++ b/collection-scripts/gather_edpm_sos
@@ -34,12 +34,16 @@ else
     IFS=',' read -r -a SOS_EDPM <<< "$SOS_EDPM"
 fi
 
-# Default to some plugins if SOS_EDPM_PROFILES is not set
+# Default to some profiles if SOS_EDPM_PROFILES is not set
 SOS_EDPM_PROFILES="${SOS_EDPM_PROFILES-system,storage,virt}"
 if [[ -n "$SOS_EDPM_PROFILES" ]]; then
     SOS_LIMIT="-p $SOS_EDPM_PROFILES"
 fi
 
+# Add plugins if SOS_EDPM_PLUGINS is nonzero
+if [[ -n "$SOS_EDPM_PLUGINS" ]]; then
+    SOS_LIMIT="$SOS_LIMIT -o $SOS_EDPM_PLUGINS"
+fi
 
 SSH () {
     ssh -i "$key_path" "${username}@${address}" -o StrictHostKeyChecking=accept-new "$@"


### PR DESCRIPTION
This patch adds the ability to pass additional sos report plugins
using the environment variable SOS_EDPM_PLUGINS. Due to [1] not being
released yet, I have added the plugins it would include and as such
should be removed when [1] is released. A todo has been added to make
this clear.

[1] https://github.com/openstack-k8s-operators/openstack-must-gather/pull/18