### PR TITLE
Optionally dump the openstack databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ This is the list of available environmental variables:
 - `SOS_EDPM_PROFILES`: List of sos report profiles to use. Empty string to run
   them all. Defaults to: `system,storage,virt`
 - `SOS_EDPM_PLUGINS`: List of sos report plugins to use. This is optional.
+- `OPENSTACK_DATABASES`: comma separated list of OpenStack databases that should
+  be dumped. It is possible to set it to `ALL` and dump all databases. By default
+  this env var is unset, hence the database dump is skipped.
+- `ADDITIONAL_NAMESPACES`: comma separated list of additional namespaces where
+  we want to gather the associated resources.
 
 ## Development
 

--- a/collection-scripts/gather_db
+++ b/collection-scripts/gather_db
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# When called from the shell directly
+if [[ -z "$DIR_NAME" ]]; then
+    CALLED=1
+    DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+    source "${DIR_NAME}/common.sh"
+fi
+
+# Default DB DUMP Option
+DB_OPT="--single-transaction --complete-insert --skip-lock-tables --lock-tables=0"
+DB_DUMP=${BASE_COLLECTION_PATH}/dbs
+
+function dump_db {
+    local dbpod="$1"
+    local ns="$2"
+    local dbpass="$3"
+    local dbname="$4"
+    local dump="${4:-openstack_databases}"
+    run_bg /usr/bin/oc -n $ns rsh -c galera $dbpod mysqldump -uroot -p$dbpass $DB_OPT $dbname > "$DB_DUMP"/$dump.sql
+}
+
+# If unset or an empty string return/exit
+if [ "${OPENSTACK_DATABASES-unset}" = "unset" ] || [[ -z "${OPENSTACK_DATABASES}" ]]; then
+    # If no databases options are passed, skip the database dump
+    echo "Skip Database dump: an empty list is provided"
+    [[ $CALLED -eq 1 ]] && exit 0
+    exit 0
+fi
+
+# Create the db_dump directory in the BASE_COLLECTION_PATH
+mkdir -p "$DB_DUMP"
+data=$(/usr/bin/oc get openstackcontrolplane --all-namespaces -o go-template='{{range $ins,$service := .items}}{{printf "%s %s\n" $service.metadata.namespace $service.spec.secret}}{{end}}')
+while read -r namespace secret; do
+    [[ -z "$namespace" || -z "$secret" ]] && break
+    # get the pwd used to run mysqldump from the galera pod
+    dbpass=$(/usr/bin/oc get -n $namespace secret/"$secret" -o go-template='{{ index .data "AdminPassword" | base64decode }}')
+    # select the (first) galera pod (and exclude the galera-cellX database services)
+    dbpod="$(/usr/bin/oc -n $namespace get pod -l app=galera --no-headers -o=custom-columns=NAME:.metadata.name | grep -v cell | tr '\n' ' ' | awk '{print $1}')"
+    if [[ "$OPENSTACK_DATABASES" == "ALL" ]]; then
+        DB_OPT="$DB_OPT --all-databases"
+        # dump all databases
+        dump_db "$dbpod" "$namespace" "$dbpass"
+    else
+        # Convert the database list to an array
+        IFS=',' read -r -a OPENSTACK_DATABASES <<< "$OPENSTACK_DATABASES"
+        # for each service dump the associated database (if exists)
+        for service in "${OPENSTACK_DATABASES[@]}"; do
+            dump_db "$dbpod" "$namespace" "$dbpass" "$service"
+        done
+    fi
+done <<< "$data"
+[[ $CALLED -eq 1 ]] && wait_bg

--- a/collection-scripts/gather_run
+++ b/collection-scripts/gather_run
@@ -56,5 +56,8 @@ source "${DIR_NAME}/gather_network"
 # get SVC status (inspect ctlplane)
 source "${DIR_NAME}/gather_services_status"
 
+# dump the openstack database
+source "${DIR_NAME}/gather_db"
+#
 # Wait for background tasks to complete
 wait_bg


### PR DESCRIPTION
This patch introduces the ability to specify an environment variable with a list of `openstack` databases that should be dumped. It is also possible to set the variable to `ALL`, which results in trigger the `mysqldump` command with the `--all-databases` option. By default the `OPENSTACK_DATABASES` variables is `unset` and this flow is entirely skipped. 
To enable it, the aforementioned variable should be explicitly set.