### PR TITLE
Mask MariaDBAccount password

### DIFF
--- a/pyscripts/mask.py
+++ b/pyscripts/mask.py
@@ -36,7 +36,7 @@ PROTECT_KEYS = [
     "ldap_dns_password", "neutron_admin_password", "admin_token",
     "ca_password" "hdfs_ssh_pw", "maprfs_ssh_pw", "powervm_mgr_passwd",
     "virtual_power_host_pass", "vnc_password", "s3_secret_key",
-    "ca_private_key_passphrase", "heartbeat_key",
+    "ca_private_key_passphrase", "heartbeat_key", "DatabasePassword",
     "server_certs_key_passphrase",
 ]
 


### PR DESCRIPTION
MariaDBAccount has been introduced in mariadb-operator and it's used to define user and secret required by a given service that requests a db. This patch adds the missing key to the mask script to cover this scenario.