### PR TITLE
Add dump-conf option to the mask secret script

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ This is the list of available environmental variables:
   this env var is unset, hence the database dump is skipped.
 - `ADDITIONAL_NAMESPACES`: comma separated list of additional namespaces where
   we want to gather the associated resources.
+- `DO_NOT_MASK`: This is an option for **CI only** purposes. It's set to 0 by
+  default (and preserves the default behavior required in a production environment).
+  However, if set to 1, it dumps secrets and services config files without masking
+  sensitive data.
 
 ## Development
 

--- a/collection-scripts/gather_secrets
+++ b/collection-scripts/gather_secrets
@@ -8,6 +8,9 @@ if [[ -z "$DIR_NAME" ]]; then
 fi
 
 PIDS=""
+# This option is used for CI only purposes and
+# is disabled by default
+DO_NOT_MASK=${DO_NOT_MASK:-0}
 
 # TODO: Get secrets where a must-gather label is set. The following command
 # get everything at the moment. All the retrieved yaml file present the .data
@@ -40,8 +43,10 @@ function gather_secrets {
     # Ensure background secret gathering tasks are done before masking secrets
     wait_bg $PIDS
 
-    # All secrets have been collected, apply masking on the entire directory
-    /usr/bin/mask.py --dir "${NAMESPACE_PATH}/${NS}/secrets"
+    if [[ "${DO_NOT_MASK}" -eq 0 ]]; then
+        # All secrets have been collected, apply masking on the entire directory
+        /usr/bin/mask.py --dump-conf --dir "${NAMESPACE_PATH}/${NS}/secrets"
+    fi
 }
 
 

--- a/pyscripts/test_mask.py
+++ b/pyscripts/test_mask.py
@@ -3,7 +3,6 @@
 import unittest
 import os
 import yaml
-import base64
 from mask import SecretMask
 
 # sample directory used to load yaml files
@@ -38,7 +37,7 @@ class TestSecretMask(unittest.TestCase):
                 actual = self._read_sample(os.path.join(root, f))
                 # Mask secret by processing the data section
                 # of the yaml file we got
-                s = SecretMask(os.path.join(root, f))
+                s = SecretMask(os.path.join(root, f), False)
                 expected = s._process_data(actual['data'])
                 """
                 files are named secret{1, 2, 3, ... N}: for these secrets

--- a/pyscripts/tests/samples/secret3.yaml
+++ b/pyscripts/tests/samples/secret3.yaml
@@ -4,6 +4,8 @@ data:
   01-config.conf: ''
   02-config.conf: ''
   03-config.conf: ''
+  tls.crt: YWJjZGVmCg==
+  tls.key: YWJjZGVmCg==
 kind: Secret
 metadata:
   name: service-config-data


### PR DESCRIPTION
This patch adds the ability to detect a `.conf` file within a `Secret` and dump its content in the current directory.
This helps to ease the _troubleshooting_ when looking for a service config file: instead of `base64 -d` a portion of the `Secret`, we provide a dump of that file in the form `<secret.yaml>-<config_file_name>.conf` within the same directory.
For CI only purposes, there are situations where is required to look at connection strings, username and passwords generated in the operators context. For this reason a `DO_NOT_MASK` environment variable is provided to entirely bypass (in CI) the masking mechanism.

Implements: [OSPRH-726](https://issues.redhat.com/browse/OSPRH-726)