### PR TITLE
Get NetworkAttachmentDefinition objects

### DIFF
--- a/collection-scripts/gather_ctlplane_resources
+++ b/collection-scripts/gather_ctlplane_resources
@@ -20,7 +20,7 @@ function gather_ctlplane_resources {
     run_bg /usr/bin/oc -n "${NS}" get all '>' "${NAMESPACE_PATH}/${NS}/all_resources.log"
     run_bg /usr/bin/oc -n "${NS}" get events '>' "${NAMESPACE_PATH}/${NS}/events.log"
     run_bg /usr/bin/oc -n "${NS}" get pvc '>' "${NAMESPACE_PATH}/${NS}/pvc.log"
-    run_bg /usr/bin/oc -n "${NS}" get nad -o yaml '>' "${NAMESPACE_PATH}/${NS}/nad.log"
+    run_bg /usr/bin/oc -n "${NS}" get network-attachment-definitions -o yaml '>' "${NAMESPACE_PATH}/${NS}/nad.log"
 
     # We make a single request to get lines in the form <pod> <container> <crash_status>
     data=$(oc -n "$NS" get pod -o go-template='{{range $indexp,$pod := .items}}{{range $index,$element := $pod.status.containerStatuses}}{{printf "%s %s" $pod.metadata.name $element.name}} {{ if ne $element.lastState.terminated nil }}{{ printf "%s" $element.lastState.terminated }}{{ end }}{{ printf "\n"}}{{end}}{{end}}')


### PR DESCRIPTION
The current script tries to get the `NetworkAttachmentDefinition` using the `nad` keyword, but that doesn't exist on the OCP cluster.

Using keyword `NetworkAttachmentDefinition` doesn't work either, only using `network-attachment-definition` or
`network-attachment-definitions` works.

This patch changes to using the plural version that works.