### PR TITLE
Sort events by timestamp

### DIFF
--- a/collection-scripts/gather_ctlplane_resources
+++ b/collection-scripts/gather_ctlplane_resources
@@ -18,7 +18,7 @@ function gather_ctlplane_resources {
     # Get the view of the current namespace related resources, including pods
     mkdir -p "${NAMESPACE_PATH}"/"${NS}"
     run_bg /usr/bin/oc -n "${NS}" get all '>' "${NAMESPACE_PATH}/${NS}/all_resources.log"
-    run_bg /usr/bin/oc -n "${NS}" get events '>' "${NAMESPACE_PATH}/${NS}/events.log"
+    run_bg /usr/bin/oc -n "${NS}" get events --sort-by='.lastTimestamp' '>' "${NAMESPACE_PATH}/${NS}/events.log"
     run_bg /usr/bin/oc -n "${NS}" get pvc '>' "${NAMESPACE_PATH}/${NS}/pvc.log"
     run_bg /usr/bin/oc -n "${NS}" get network-attachment-definitions -o yaml '>' "${NAMESPACE_PATH}/${NS}/nad.log"
 


### PR DESCRIPTION
https://logserver.rdoproject.org/47/47/67bc7d39d5f268d35c6e2e3184e8a89b7e64da10/github-check/podified-multinode-edpm-deployment-crc/76e3cad/controller/ci-framework-data/logs/quay-rdoproject-org-openstack-k8s-operators-openstack-must-gather-sha256-adfecf98bc58627d20b87c9e4f29a9b97dfce40bf0cfebb4a32e789c3caed8fb/namespaces/openstack/events.log