### PR TITLE
Collect all the logs related to openshift-marketplace

### DIFF
--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -10,6 +10,7 @@ declare -a DEFAULT_NAMESPACES=(
     "openshift-machine-api"
     "cert-manager"
     "openshift-nmstate"
+    "openshift-marketplace"
 )
 export DEFAULT_NAMESPACES
 


### PR DESCRIPTION
Many times certmanager operator installation fails in CI. certmanager-operator comes from openshift-marketplace namespace.

os-must-gather does not collects logs related to
openshift-marketplace namespace.

Capturing the logs from openshift-marketplace will help us to diagnose certmanager operator related issues.

