### PR TITLE
Use `$node.hostName` if `$node.ansible.ansibleHost` isn't available

### DIFF
--- a/collection-scripts/gather_edpm_sos
+++ b/collection-scripts/gather_edpm_sos
@@ -100,7 +100,7 @@ gather_edpm_sos () {
 }
 
 
-data=$(oc get openstackdataplanenodesets --all-namespaces -o go-template='{{range $indexns,$nodeset := .items}}{{range $index,$node := $nodeset.spec.nodes}}{{printf "%s %s %s %s %s\n" $node.hostName $node.ansible.ansibleHost $nodeset.spec.nodeTemplate.ansible.ansibleUser $nodeset.spec.nodeTemplate.ansibleSSHPrivateKeySecret $nodeset.metadata.namespace}}{{end}}{{end}}')
+data=$(oc get openstackdataplanenodesets --all-namespaces -o go-template='{{range $indexns,$nodeset := .items}}{{range $index,$node := $nodeset.spec.nodes}}{{printf "%s " $node.hostName}}{{if $node.ansible.ansibleHost}}{{printf "%s " $node.ansible.ansibleHost}}{{else}}{{printf "%s " $node.hostName}}{{end}}{{printf "%s %s %s\n" $nodeset.spec.nodeTemplate.ansible.ansibleUser $nodeset.spec.nodeTemplate.ansibleSSHPrivateKeySecret $nodeset.metadata.namespace}}{{end}}{{end}}')
 
 while read -r node address username secret namespace; do
     [[ -z "$node" ]] && continue


### PR DESCRIPTION
If in the `openstackdataplanenodesets` resources the `$node.ansible.ansibleHost` is not defined, the must-gather from the compute nodes fails with this kind of error:

```
[must-gather-27lcm] POD 2024-04-26T22:51:13.104464074Z /usr/bin/bg.sh: eval: line 30: syntax error near unexpected token `('
[must-gather-27lcm] POD 2024-04-26T22:51:13.104464074Z /usr/bin/bg.sh: eval: line 30: `gather_edpm_sos compute-0 %!s(<nil>) zuul dataplane-ansible-ssh-private-key-secret openstack'
[must-gather-27lcm] POD 2024-04-26T22:51:13.104464074Z /usr/bin/bg.sh: eval: line 30: syntax error near unexpected token `('
[must-gather-27lcm] POD 2024-04-26T22:51:13.104464074Z /usr/bin/bg.sh: eval: line 30: `gather_edpm_sos compute-1 %!s(<nil>) zuul dataplane-ansible-ssh-private-key-secret openstack'
[must-gather-27lcm] POD 2024-04-26T22:51:13.104464074Z /usr/bin/bg.sh: eval: line 30: syntax error near unexpected token `('
[must-gather-27lcm] POD 2024-04-26T22:51:13.104464074Z /usr/bin/bg.sh: eval: line 30: `gather_edpm_sos compute-2 %!s(<nil>) zuul dataplane-ansible-ssh-private-key-secret openstack'
```

To avoid this behavior, we are going to pass `$node.hostName` as `address` parameter