### PR TITLE
Gather telemetry logging related resources

### DIFF
--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -10,6 +10,8 @@ declare -a DEFAULT_NAMESPACES=(
     "openshift-machine-api"
     "cert-manager"
     "openshift-nmstate"
+    "openshift-operators-redhat"
+    "openshift-logging"
 )
 export DEFAULT_NAMESPACES
 

--- a/collection-scripts/gather_crs
+++ b/collection-scripts/gather_crs
@@ -13,7 +13,8 @@ crs=()
 # Explictly adding rabbit in the grep because its CRD is named with a different domain.
 # Also adding monitoring.rhobs, because telemetry uses observability-operator
 # to deploy a `MonitoringStack` for storing and scraping metrics.
-for i in $(/usr/bin/oc get crd | grep -E "(openstack|rabbitmq|monitoring)\.(org|com|rhobs)" | awk '{print $1}')
+# Adding grafana.com and logging.openshift.io because of resources used by telemetry logging.
+for i in $(/usr/bin/oc get crd | grep -E "(openstack|rabbitmq|monitoring|grafana|logging\.openshift)\.(org|com|rhobs|io)" | awk '{print $1}')
 do
   crs+=("$i")
 done


### PR DESCRIPTION
This are mainly resources in the openshift-logging and openshift-operators-redhat namespaces.