### PR TITLE
SOS Report: Get rotated container logs

### DIFF
--- a/collection-scripts/gather_ctlplane_resources
+++ b/collection-scripts/gather_ctlplane_resources
@@ -22,21 +22,14 @@ function gather_ctlplane_resources {
     run_bg /usr/bin/oc -n "${NS}" get pvc '>' "${NAMESPACE_PATH}/${NS}/pvc.log"
     run_bg /usr/bin/oc -n "${NS}" get network-attachment-definitions -o yaml '>' "${NAMESPACE_PATH}/${NS}/nad.log"
 
-    # We make a single request to get lines in the form <pod> <container> <crash_status>
-    data=$(oc -n "$NS" get pod -o go-template='{{range $indexp,$pod := .items}}{{range $index,$element := $pod.status.containerStatuses}}{{printf "%s %s" $pod.metadata.name $element.name}} {{ if ne $element.lastState.terminated nil }}{{ printf "%s" $element.lastState.terminated }}{{ end }}{{ printf "\n"}}{{end}}{{end}}')
-    while read -r pod container crash_status; do
-        echo "Dump logs for ${container} from ${pod} pod";
-        pod_dir="${NAMESPACE_PATH}/${NS}/pods/${pod}"
-        log_dir="${pod_dir}/logs"
-        if [ ! -d "$log_dir" ]; then
-            mkdir -p "$log_dir"
-            # describe pod
-            run_bg oc -n "$NS" describe pod "$pod" '>' "${pod_dir}/${pod}-describe"
-        fi
-        run_bg oc -n "$NS" logs "$pod" -c "$container" '>' "${log_dir}/${container}.log"
-        if [[ -n "$crash_status" ]]; then
-            run_bg oc -n "$NS" logs "$pod" -c "$container" --previous '>' "${log_dir}/${container}-previous.log";
-        fi
+    # Don't gather the logs here, they are all gathered from /var/log/pods in gather_sos
+    pods_dir="${NAMESPACE_PATH}/${NS}/pods/"
+    mkdir -p "${pods_dir}"
+    data=$(oc -n "$NS" get pod --no-headers -o custom-columns=":metadata.name")
+    while read -r pod; do
+        echo "Describe pod ${pod}";
+        # describe pod
+        run_bg oc -n "$NS" describe pod "$pod" '>' "${pods_dir}/${pod}-describe"
     done <<< "$data"
 
     # get the required resources

--- a/collection-scripts/gather_run
+++ b/collection-scripts/gather_run
@@ -3,6 +3,9 @@
 DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "${DIR_NAME}/common.sh"
 
+# Trigger Guru Meditation Reports to have them in SOS report pod logs
+source "${DIR_NAME}/gather_trigger_gmr"
+
 # get SOS Reports first, as they are the slowest to run and will benefit most
 # of the parallel execution
 source "${DIR_NAME}/gather_sos"
@@ -28,9 +31,6 @@ source "${DIR_NAME}/gather_webhooks"
 # logs
 expand_ns
 
-# Trigger Guru Meditation Reports so we then have then in the service logs
-source "${DIR_NAME}/gather_trigger_gmr"
-
 # Import functions used in the for loop
 source "${DIR_NAME}/gather_services_cm"
 source "${DIR_NAME}/gather_secrets"
@@ -46,7 +46,7 @@ for NS in "${DEFAULT_NAMESPACES[@]}"; do
     gather_sub "$NS"
     # get routes, services, jobs, deployments
     # daemonsets, statefulsets, replicasets,
-    # pods (describe and get logs)
+    # pods (describe)
     gather_ctlplane_resources "$NS"
 done
 

--- a/collection-scripts/gather_sos
+++ b/collection-scripts/gather_sos
@@ -103,14 +103,17 @@ gather_node_sos () {
     echo "Retrieving SOS Report for ${node}"
     # Hint the need to use -i when using tar because there are 2 tars in a single file
     sos_file="${SOS_PATH_NODES}/sosreport-$node-UntarWithArg-i.tar.xz"
+    download_logs="${SOS_PATH_NODES}/sosreport-$node.tar.xz-download.logs"
     # Add "--loglevel 6" to help debug in case there's a failure
-    oc debug --loglevel 6 "node/$node" -- bash -c "cat \"/host${TMPDIR}/\"*.tar.xz" | tee "${sos_file}"
+    oc debug --loglevel 6 "node/$node" -- bash -c "cat \"/host${TMPDIR}/\"*.tar.xz" 2> "${download_logs}" 1> "${sos_file}"
 
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
         echo "Failed to download sosreport-$node.tar.xz not deleting file"
         return 1
     fi
+
+    rm "${download_logs}"
 
     # if we are decompressing the sos report, remove the original sos archive
     if [[ ${SOS_DECOMPRESS} -eq 1 ]]; then

--- a/collection-scripts/gather_sos
+++ b/collection-scripts/gather_sos
@@ -101,7 +101,6 @@ gather_node_sos () {
     # Not decompressing at this stage outside of a CI environment would
     # require changes be made to the yank tool
     echo "Retrieving SOS Report for ${node}"
-    mkdir "${SOS_PATH_NODES}/sosreport-$node"
     # Hint the need to use -i when using tar because there are 2 tars in a single file
     sos_file="${SOS_PATH_NODES}/sosreport-$node-UntarWithArg-i.tar.xz"
     # Add "--loglevel 6" to help debug in case there's a failure
@@ -115,12 +114,12 @@ gather_node_sos () {
 
     # if we are decompressing the sos report, remove the original sos archive
     if [[ ${SOS_DECOMPRESS} -eq 1 ]]; then
+        mkdir "${SOS_PATH_NODES}/sosreport-$node"
         tar -i --one-top-level="${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf "${sos_file}"
         rm "${sos_file}"
+        # Ensure write access to the sos reports directories so must-gather rsync doesn't fail
+        chmod +w -R "${SOS_PATH_NODES}/sosreport-$node/"
     fi
-
-    # Ensure write access to the sos reports directories so must-gather rsync doesn't fail
-    chmod +w -R "${SOS_PATH_NODES}/sosreport-$node/"
 
     sleep 1
     # Delete the tar.xz file from the remote node

--- a/collection-scripts/gather_sos
+++ b/collection-scripts/gather_sos
@@ -63,18 +63,24 @@ gather_node_sos () {
     # Can only run 1 must-gather at a time on each host. We remove any existing
     # toolbox container running from previous time with `podman rm`
     #
-    # Current toolbox can ask via stdin if we want to update [1] so we just
-    # update the container beforehand to prevent it from ever asking. In the
-    # next toolbox [2] that may no longer be the case.
-    # [1]: https://github.com/coreos/toolbox/blob/9a7c840fb4881f406287bf29e5f35b6625c7b358/rhcos-toolbox#L37
-    # [2]: https://github.com/coreos/toolbox/issues/60
+    # - Current toolbox can ask via stdin if we want to update [1] so we just
+    #   update the container beforehand to prevent it from ever asking. In the
+    #   next toolbox [2] that may no longer be the case.
+    #   [1]: https://github.com/coreos/toolbox/blob/9a7c840fb4881f406287bf29e5f35b6625c7b358/rhcos-toolbox#L37
+    #   [2]: https://github.com/coreos/toolbox/issues/60
+    # - Use 2 tar files instead of 1 since tar's "-n --concatenate" and "--append" don't support compressed files
+    # - Use tar's transform when adding /var/log/pods so "var" is not removed when untaring with --strip-components
+    #   To avoid performance penalty we don't look for the real directory name using:
+    #     $(tar --exclude='*/*' -tf "${FILENAME}" | head -n1)
+    #   Instead we use a fake podlogs top directory
     oc debug "node/$node" -- chroot /host bash \
       -c "echo 'TOOLBOX_NAME=toolbox-osp' > /root/.toolboxrc ; \
           rm -rf \"${TMPDIR}\" && \
           mkdir -p \"${TMPDIR}\" && \
           sudo podman rm --force toolbox-osp;  \
           sudo --preserve-env podman pull --authfile /var/lib/kubelet/config.json registry.redhat.io/rhel9/support-tools && \
-          toolbox sos report --batch $SOS_LIMIT --tmp-dir=\"${TMPDIR}\""
+          toolbox sos report --batch $SOS_LIMIT --tmp-dir=\"${TMPDIR}\" && \
+          tar --warning=no-file-changed -cJf \"${TMPDIR}/podlogs.tar.xz\" --transform 's,^,podlogs/,' /var/log/pods"
 
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
@@ -96,8 +102,10 @@ gather_node_sos () {
     # require changes be made to the yank tool
     echo "Retrieving SOS Report for ${node}"
     mkdir "${SOS_PATH_NODES}/sosreport-$node"
+    # Hint the need to use -i when using tar because there are 2 tars in a single file
+    sos_file="${SOS_PATH_NODES}/sosreport-$node-UntarWithArg-i.tar.xz"
     # Add "--loglevel 6" to help debug in case there's a failure
-    oc debug --loglevel 6 "node/$node" -- bash -c "cat \"/host${TMPDIR}/\"*.tar.xz" | tee "${SOS_PATH_NODES}/sosreport-$node.tar.xz"
+    oc debug --loglevel 6 "node/$node" -- bash -c "cat \"/host${TMPDIR}/\"*.tar.xz" | tee "${sos_file}"
 
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
@@ -105,11 +113,10 @@ gather_node_sos () {
         return 1
     fi
 
-    # if were decompressing the sos report, remove the
-    # original sos archive
+    # if we are decompressing the sos report, remove the original sos archive
     if [[ ${SOS_DECOMPRESS} -eq 1 ]]; then
-        tar --one-top-level="${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf ${SOS_PATH_NODES}/sosreport-$node.tar.xz
-        rm "${SOS_PATH_NODES}/sosreport-$node.tar.xz"
+        tar -i --one-top-level="${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf "${sos_file}"
+        rm "${sos_file}"
     fi
 
     # Ensure write access to the sos reports directories so must-gather rsync doesn't fail


### PR DESCRIPTION
Current must gather only gathers the logs in the pod's current log file
and the previous container run, so once the logs are rotated we no
longer have access to that information through the `oc` command and that
information is not present in the must gather tar.xz.

Rotated logs are only available under `/var/log/pods` and, since log
rotation is not an OpenShift responsibility, there is no way to get them
besides accessing that directory.

There is no sos plugin that gathers the contents of `/var/log/pods` only
for `/var/log/containers`, but in this last directory there are only
symlinks to the last files, not the rotated ones.

I see 3 ways to solve this issue:

- Submit a PR to upstream SOS report repository with a new plugin to
  gather that directory. This would take time and we would need to wait
  until it gets merged and released upstream, then released downstream,
  and a new container is built using the latest release.

- Create a custom toolbox container image based on the RHEL9 one that
  has our custom SOS report plugin and use it in openstack-must-gather.
  This means that we would have to productize another container.

- Just compress and transfer manually the whole directory.

This patch takes the last of these approaches, as it is fast and easy to
implement and is not affected by the size limits that logs in sos
reports usually have.

The approach creates a tar.xz in the same debug container as the sos
report and then both are transferred simultaneously using the same debug
container.

Since the new tar.xz file will contain all the logs we no longer need to
run all those individual `oc logs` commands we were running before.

Jira: https://issues.redhat.com/browse/OSPRH-7615