### PR TITLE
Introduce openshiftclient ARG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM quay.io/openshift/origin-must-gather:4.15.0 as builder
 
 FROM quay.io/centos/centos:stream9
 
+ARG openshiftclient
+
 RUN dnf update -y && dnf install jq xz rsync python3-pyyaml openssh-clients -y && dnf clean all
 
 COPY --from=builder /usr/bin/oc /usr/bin/oc
@@ -14,6 +16,13 @@ COPY collection-scripts/* /usr/bin/
 
 # Copy the python script used to mask sensitive data
 COPY pyscripts/mask.py /usr/bin/
+
+# When fips is enabled, install the fips complaint openshift-client
+RUN if [ "$openshiftclient" != "" ]; then \
+    curl -o openshift-client "${openshiftclient}" && \
+    tar -xzvf openshift-client && mv ./oc /usr/bin/oc && \
+    rm {openshift-client,README.md,kubectl}; \
+    fi
 
 # Entrypoint not used when calling `oc adm must-gather`
 ENTRYPOINT /usr/bin/gather

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 IMAGE_REGISTRY ?= quay.io/openstack-k8s-operators
 IMAGE_TAG ?= latest
 
+# Extra vars which will be passed to the Docker-build
+BUILD_ARGS ?=
+DOCKER_BUILD_ARGS ?= --build-arg $(BUILD_ARGS)
+
 check-image: ## Check if the MUST_GATHER_IMAGE variable is set
 ifndef MUST_GATHER_IMAGE
 	$(error MUST_GATHER_IMAGE is not set.)
@@ -15,7 +19,7 @@ pytest: ## Run sanity check against python scripts in pydir
 	tox -c pyscripts/tox.ini
 
 podman-build: check-image ## build the must-gather image
-	podman build -t ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG} .
+	podman build -t ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG} . ${DOCKER_BUILD_ARGS}
 
 podman-push: check-image ## push the must-gather image to the image registry
 	podman push ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG}

--- a/README.md
+++ b/README.md
@@ -228,6 +228,20 @@ The targets for `make` are as follows:
 - `podman-build`: builds the must-gather image
 - `podman-push`:  pushes an already-built `must-gather` image
 
+It is possible to override the openshift-client version within the resulting
+openstack-must-gather image using the optional `BUILD_ARGS` environment variable.
+For example, assuming the goal is to inject a `4.15` openshift-client, you can
+run:
+
+```bash
+
+$ OCP_CLIENT_TARGET=https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.15.9/openshift-client-linux-amd64-rhel9-4.15.9.tar.gz
+
+$ BUILD_ARGS=openshiftclient="${OCP_CLIENT_TARGET}" <parameters> make build
+```
+
+- Replace <parameters> with the registry and image name data.
+
 ### Debugging container
 
 One possible workflow that can be used for development is to run the openstack


### PR DESCRIPTION
For `FIPS` we need a compliant `openshift-client`. With the current patch is possible to replace the `openshift-client` coming from the base image with the one passed as input at build time.