### PR TITLE
Revert "SOS Report: Get rotated container logs"

### DIFF
--- a/collection-scripts/gather_ctlplane_resources
+++ b/collection-scripts/gather_ctlplane_resources
@@ -22,14 +22,21 @@ function gather_ctlplane_resources {
     run_bg /usr/bin/oc -n "${NS}" get pvc '>' "${NAMESPACE_PATH}/${NS}/pvc.log"
     run_bg /usr/bin/oc -n "${NS}" get network-attachment-definitions -o yaml '>' "${NAMESPACE_PATH}/${NS}/nad.log"
 
-    # Don't gather the logs here, they are all gathered from /var/log/pods in gather_sos
-    pods_dir="${NAMESPACE_PATH}/${NS}/pods/"
-    mkdir -p "${pods_dir}"
-    data=$(oc -n "$NS" get pod --no-headers -o custom-columns=":metadata.name")
-    while read -r pod; do
-        echo "Describe pod ${pod}";
-        # describe pod
-        run_bg oc -n "$NS" describe pod "$pod" '>' "${pods_dir}/${pod}-describe"
+    # We make a single request to get lines in the form <pod> <container> <crash_status>
+    data=$(oc -n "$NS" get pod -o go-template='{{range $indexp,$pod := .items}}{{range $index,$element := $pod.status.containerStatuses}}{{printf "%s %s" $pod.metadata.name $element.name}} {{ if ne $element.lastState.terminated nil }}{{ printf "%s" $element.lastState.terminated }}{{ end }}{{ printf "\n"}}{{end}}{{end}}')
+    while read -r pod container crash_status; do
+        echo "Dump logs for ${container} from ${pod} pod";
+        pod_dir="${NAMESPACE_PATH}/${NS}/pods/${pod}"
+        log_dir="${pod_dir}/logs"
+        if [ ! -d "$log_dir" ]; then
+            mkdir -p "$log_dir"
+            # describe pod
+            run_bg oc -n "$NS" describe pod "$pod" '>' "${pod_dir}/${pod}-describe"
+        fi
+        run_bg oc -n "$NS" logs "$pod" -c "$container" '>' "${log_dir}/${container}.log"
+        if [[ -n "$crash_status" ]]; then
+            run_bg oc -n "$NS" logs "$pod" -c "$container" --previous '>' "${log_dir}/${container}-previous.log";
+        fi
     done <<< "$data"
 
     # get the required resources

--- a/collection-scripts/gather_run
+++ b/collection-scripts/gather_run
@@ -3,9 +3,6 @@
 DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "${DIR_NAME}/common.sh"
 
-# Trigger Guru Meditation Reports to have them in SOS report pod logs
-source "${DIR_NAME}/gather_trigger_gmr"
-
 # get SOS Reports first, as they are the slowest to run and will benefit most
 # of the parallel execution
 source "${DIR_NAME}/gather_sos"
@@ -31,6 +28,9 @@ source "${DIR_NAME}/gather_webhooks"
 # logs
 expand_ns
 
+# Trigger Guru Meditation Reports so we then have then in the service logs
+source "${DIR_NAME}/gather_trigger_gmr"
+
 # Import functions used in the for loop
 source "${DIR_NAME}/gather_services_cm"
 source "${DIR_NAME}/gather_secrets"
@@ -46,7 +46,7 @@ for NS in "${DEFAULT_NAMESPACES[@]}"; do
     gather_sub "$NS"
     # get routes, services, jobs, deployments
     # daemonsets, statefulsets, replicasets,
-    # pods (describe)
+    # pods (describe and get logs)
     gather_ctlplane_resources "$NS"
 done
 

--- a/collection-scripts/gather_sos
+++ b/collection-scripts/gather_sos
@@ -63,24 +63,18 @@ gather_node_sos () {
     # Can only run 1 must-gather at a time on each host. We remove any existing
     # toolbox container running from previous time with `podman rm`
     #
-    # - Current toolbox can ask via stdin if we want to update [1] so we just
-    #   update the container beforehand to prevent it from ever asking. In the
-    #   next toolbox [2] that may no longer be the case.
-    #   [1]: https://github.com/coreos/toolbox/blob/9a7c840fb4881f406287bf29e5f35b6625c7b358/rhcos-toolbox#L37
-    #   [2]: https://github.com/coreos/toolbox/issues/60
-    # - Use 2 tar files instead of 1 since tar's "-n --concatenate" and "--append" don't support compressed files
-    # - Use tar's transform when adding /var/log/pods so "var" is not removed when untaring with --strip-components
-    #   To avoid performance penalty we don't look for the real directory name using:
-    #     $(tar --exclude='*/*' -tf "${FILENAME}" | head -n1)
-    #   Instead we use a fake podlogs top directory
+    # Current toolbox can ask via stdin if we want to update [1] so we just
+    # update the container beforehand to prevent it from ever asking. In the
+    # next toolbox [2] that may no longer be the case.
+    # [1]: https://github.com/coreos/toolbox/blob/9a7c840fb4881f406287bf29e5f35b6625c7b358/rhcos-toolbox#L37
+    # [2]: https://github.com/coreos/toolbox/issues/60
     oc debug "node/$node" -- chroot /host bash \
       -c "echo 'TOOLBOX_NAME=toolbox-osp' > /root/.toolboxrc ; \
           rm -rf \"${TMPDIR}\" && \
           mkdir -p \"${TMPDIR}\" && \
           sudo podman rm --force toolbox-osp;  \
           sudo --preserve-env podman pull --authfile /var/lib/kubelet/config.json registry.redhat.io/rhel9/support-tools && \
-          toolbox sos report --batch $SOS_LIMIT --tmp-dir=\"${TMPDIR}\" && \
-          tar --warning=no-file-changed -cJf \"${TMPDIR}/podlogs.tar.xz\" --transform 's,^,podlogs/,' /var/log/pods"
+          toolbox sos report --batch $SOS_LIMIT --tmp-dir=\"${TMPDIR}\""
 
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
@@ -101,11 +95,9 @@ gather_node_sos () {
     # Not decompressing at this stage outside of a CI environment would
     # require changes be made to the yank tool
     echo "Retrieving SOS Report for ${node}"
-    # Hint the need to use -i when using tar because there are 2 tars in a single file
-    sos_file="${SOS_PATH_NODES}/sosreport-$node-UntarWithArg-i.tar.xz"
-    download_logs="${SOS_PATH_NODES}/sosreport-$node.tar.xz-download.logs"
+    mkdir "${SOS_PATH_NODES}/sosreport-$node"
     # Add "--loglevel 6" to help debug in case there's a failure
-    oc debug --loglevel 6 "node/$node" -- bash -c "cat \"/host${TMPDIR}/\"*.tar.xz" 2> "${download_logs}" 1> "${sos_file}"
+    oc debug --loglevel 6 "node/$node" -- bash -c "cat \"/host${TMPDIR}/\"*.tar.xz" | tee "${SOS_PATH_NODES}/sosreport-$node.tar.xz"
 
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
@@ -113,16 +105,15 @@ gather_node_sos () {
         return 1
     fi
 
-    rm "${download_logs}"
-
-    # if we are decompressing the sos report, remove the original sos archive
+    # if were decompressing the sos report, remove the
+    # original sos archive
     if [[ ${SOS_DECOMPRESS} -eq 1 ]]; then
-        mkdir "${SOS_PATH_NODES}/sosreport-$node"
-        tar -i --one-top-level="${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf "${sos_file}"
-        rm "${sos_file}"
-        # Ensure write access to the sos reports directories so must-gather rsync doesn't fail
-        chmod +w -R "${SOS_PATH_NODES}/sosreport-$node/"
+        tar --one-top-level="${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf ${SOS_PATH_NODES}/sosreport-$node.tar.xz
+        rm "${SOS_PATH_NODES}/sosreport-$node.tar.xz"
     fi
+
+    # Ensure write access to the sos reports directories so must-gather rsync doesn't fail
+    chmod +w -R "${SOS_PATH_NODES}/sosreport-$node/"
 
     sleep 1
     # Delete the tar.xz file from the remote node


### PR DESCRIPTION
Reverts openstack-k8s-operators/openstack-must-gather#56 

It seems that this caused that in majority of the cases must-gather failed to collect the sos-report form the OCP nodes.

```
[must-gather-lxkg7] POD 2024-06-14T02:36:55.328873111Z Your sosreport has been generated and saved in:
[must-gather-lxkg7] POD 2024-06-14T02:36:55.328873111Z  /host/var/tmp/sos-osp/sosreport-master-1-2024-06-14-yrzlkgr.tar.xz
[must-gather-lxkg7] POD 2024-06-14T02:36:55.328873111Z 
[must-gather-lxkg7] POD 2024-06-14T02:36:55.328873111Z  Size    8.38MiB
[must-gather-lxkg7] POD 2024-06-14T02:36:55.328873111Z  Owner   root
[must-gather-lxkg7] POD 2024-06-14T02:36:55.328873111Z  sha256  86a020df68ff5d8422282a5c7bef5982c683552534c6d3bd6cd5f203dd82d021
[must-gather-lxkg7] POD 2024-06-14T02:36:55.328873111Z 
[must-gather-lxkg7] POD 2024-06-14T02:36:55.328873111Z Please send this file to your support representative.
[must-gather-lxkg7] POD 2024-06-14T02:36:55.328873111Z 
[must-gather-lxkg7] POD 2024-06-14T02:36:55.331206568Z exit
[must-gather-lxkg7] POD 2024-06-14T02:36:55.340601819Z 
[must-gather-lxkg7] POD 2024-06-14T02:36:55.809337362Z tar: Removing leading `/' from member names
...

[must-gather-lxkg7] POD 2024-06-14T02:38:53.662484301Z error: non-zero exit code from debug container
[must-gather-lxkg7] POD 2024-06-14T02:38:53.665922594Z Failed to run sos report on node master-1, won't retrieve data
```

See more in: https://redhat-internal.slack.com/archives/CQXJFGMK6/p1718367364462659?thread_ts=1717766176.033309&cid=CQXJFGMK6
