### PR TITLE
Fix pod log gathering

### DIFF
--- a/collection-scripts/gather_sos
+++ b/collection-scripts/gather_sos
@@ -73,6 +73,7 @@ gather_node_sos () {
     #   To avoid performance penalty we don't look for the real directory name using:
     #     $(tar --exclude='*/*' -tf "${FILENAME}" | head -n1)
     #   Instead we use a fake podlogs top directory
+    # - Ignore warning exit code (1) from tar, and only consider it a failure on error code (2)
     oc debug "node/$node" -- chroot /host bash \
       -c "echo 'TOOLBOX_NAME=toolbox-osp' > /root/.toolboxrc ; \
           rm -rf \"${TMPDIR}\" && \
@@ -80,7 +81,7 @@ gather_node_sos () {
           sudo podman rm --force toolbox-osp;  \
           sudo --preserve-env podman pull --authfile /var/lib/kubelet/config.json registry.redhat.io/rhel9/support-tools && \
           toolbox sos report --batch $SOS_LIMIT --tmp-dir=\"${TMPDIR}\" && \
-          tar --warning=no-file-changed -cJf \"${TMPDIR}/podlogs.tar.xz\" --transform 's,^,podlogs/,' /var/log/pods"
+          tar --warning=no-file-changed -cJf \"${TMPDIR}/podlogs.tar.xz\" --transform 's,^,podlogs/,' /var/log/pods; [ \$? -lt 2 ]"
 
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
Some tar versions return exit code 1 on warnings such as file changed during read, other return exit code 0.

With this patch the tar command run used to gather /var/log/pods will only be considered failed if the exit code is 2 or greater.