### PR TITLE
Cleaner logs on EDPM SOS reports

### DIFF
--- a/collection-scripts/gather_edpm_sos
+++ b/collection-scripts/gather_edpm_sos
@@ -82,7 +82,8 @@ gather_edpm_sos () {
 
     echo "Retrieving SOS Report for ${node}"
     mkdir -p "${SOS_PATH_NODES}/sosreport-$node"
-    SSH sudo "cat ${TMPDIR}/*.tar.xz" | tee "${SOS_PATH_NODES}/sosreport-$node.tar.xz"
+    # Redirect tar contents to file and stderr to stding
+    { SSH sudo "cat ${TMPDIR}/*.tar.xz" 1> "${SOS_PATH_NODES}/sosreport-$node.tar.xz"; } 2>&1
 
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
When we are downloading the SOS reports from EDPM nodes, the whole tar data is shown in stdout, making them a mess.

In this patch we change how we get the SOS from the nodes, and instead of using `tee`, we redirect stdout to the file and stderr to stdout, so we still see any errors on the download but we no longer have to see the whole tar in stdout.