### PR TITLE
Fix missing EDPM SOS reports

### DIFF
--- a/collection-scripts/gather_edpm_sos
+++ b/collection-scripts/gather_edpm_sos
@@ -50,7 +50,7 @@ if [[ -n "$SOS_EDPM_PLUGINS" ]]; then
 fi
 
 SSH () {
-    ssh -i "$key_path" "${username}@${address}" -o StrictHostKeyChecking=accept-new "$@"
+    ssh -n -i "$key_path" "${username}@${address}" -o StrictHostKeyChecking=accept-new "$@"
 }
 
 gather_edpm_sos () {


### PR DESCRIPTION
The must-gather failed to collect SOS reports from more than CONCURRENCY
nodes. It is caused by ssh reading the stdin and consuming data used by
the outer loop iterating over the nodes to be collected from.

Added -n to ssh to avoid stdin stealing.
