### PR TITLE
[SOS EDPM] Use openstack_edpm profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This is the list of available environmental variables:
   empty string skips sos report gathering. Accepts keyword all to gather all
   nodes. eg: `edpm-compute-0,edpm-compute-1`
 - `SOS_EDPM_PROFILES`: List of sos report profiles to use. Empty string to run
-  them all. Defaults to: `system,storage,virt`
+  them all. Defaults to: `container,openstack_edpm,system,storage,virt`
 - `SOS_EDPM_PLUGINS`: List of sos report plugins to use. This is optional.
 - `OPENSTACK_DATABASES`: comma separated list of OpenStack databases that should
   be dumped. It is possible to set it to `ALL` and dump all databases. By default

--- a/collection-scripts/gather_edpm_sos
+++ b/collection-scripts/gather_edpm_sos
@@ -39,7 +39,7 @@ else
 fi
 
 # Default to some profiles if SOS_EDPM_PROFILES is not set
-SOS_EDPM_PROFILES="${SOS_EDPM_PROFILES-container,openstack,system,storage,virt}"
+SOS_EDPM_PROFILES="${SOS_EDPM_PROFILES-container,openstack_edpm,system,storage,virt}"
 if [[ -n "$SOS_EDPM_PROFILES" ]]; then
     SOS_LIMIT="-p $SOS_EDPM_PROFILES"
 fi

--- a/collection-scripts/gather_sos
+++ b/collection-scripts/gather_sos
@@ -40,7 +40,7 @@ else
 fi
 
 # Default to some plugins if SOS_ONLY_PLUGINS is not set
-SOS_ONLY_PLUGINS="${SOS_ONLY_PLUGINS-block,cifs,crio,devicemapper,devices,iscsi,lvm2,memory,multipath,nfs,nis,nvme,podman,process,processor,selinux,scsi,udev,openstack_edpm,logs}"
+SOS_ONLY_PLUGINS="${SOS_ONLY_PLUGINS-block,cifs,crio,devicemapper,devices,iscsi,lvm2,memory,multipath,nfs,nis,nvme,podman,process,processor,selinux,scsi,udev,logs}"
 if [[ -n "$SOS_ONLY_PLUGINS" ]]; then
     SOS_LIMIT="--only-plugins $SOS_ONLY_PLUGINS"
 fi


### PR DESCRIPTION
The `openstack_edpm` plugin was being gathered on the OCP cluster nodes, but it's intended for the EDPM nodes, so we remove it from the list of plugins in `SOS_ONLY_PLUGINS`.

We move the `openstack_edpm` to the EDPM sos gathering script replacing the old `openstack` profile that is not as appropriate for openstack-operator deployments.