### PR TITLE
Cinder GMR triggering

### DIFF
--- a/collection-scripts/gather_trigger_gmr
+++ b/collection-scripts/gather_trigger_gmr
@@ -42,7 +42,8 @@ cinder_trigger_gmr() {
     # with the host so we don't know what PID the service has
     while read -r line; do
         podname="${line% *}"
-        svctype="${line#* }"
+        svctype="${line##* }"
+        [ "${svctype}" == '<none>' ] && continue
         run_bg $oce $podname -c $svctype -- touch /etc/cinder
     done <<< "$svcs"
 }


### PR DESCRIPTION
When gathering data we can see the following error

```
/usr/bin/bg.sh: line 30: none: No such file or directory
```

This is caused by the `gather_trigger_gmr` trying to run in the background the following command:

```
/usr/bin/oc -n openstack  exec  cinder-db-purge-28654561-hx97v   -c   <none> -- touch /etc/cinder
```

This patch makes it so that the code no longer tries to trigger GMR on pods that are not cinder services (these pods have the component label set).