### PR TITLE
Produce a single archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ This is the list of available environmental variables:
   default (and preserves the default behavior required in a production environment).
   However, if set to 1, it dumps secrets and services config files without masking
   sensitive data.
+- `COMPRESSED_PATH`: defines the path to store the compressed form of the
+  gathered data
+- `DELETE_AFTER_COMPRESSION`: 0 or 1. When set to 1 the uncompressed data is
+  deleted after the archive is created. Defaulted to 0.
 
 ### Inspect gathered data
 

--- a/collection-scripts/gather_run
+++ b/collection-scripts/gather_run
@@ -64,3 +64,10 @@ wait_bg
 
 # Create rotated log symlinks after everything else has finished
 rotated_logs_symlinks
+
+# create an easy to download tar from the whole content
+tar \
+    --exclude='must-gather.tar.xz' \
+    --warning=no-file-changed --ignore-failed  \
+    -cJf \
+    "${BASE_COLLECTION_PATH}/must-gather.tar.xz" "${BASE_COLLECTION_PATH}" || true

--- a/collection-scripts/gather_run
+++ b/collection-scripts/gather_run
@@ -65,9 +65,24 @@ wait_bg
 # Create rotated log symlinks after everything else has finished
 rotated_logs_symlinks
 
-# create an easy to download tar from the whole content
+# The path to store the compressed result
+export COMPRESSED_PATH=${COMPRESSED_PATH:-"${BASE_COLLECTION_PATH}"}
+# whether to delete or keep the uncompressed files.
+# Defaults to keep them.
+export DELETE_AFTER_COMPRESSION=${DELETE_AFTER_COMPRESSION:-0}
+
+# create an easy to download tar.xz from the whole content
+archive="${COMPRESSED_PATH}/must-gather.tar.xz"
+
 tar \
     --exclude='must-gather.tar.xz' \
     --warning=no-file-changed --ignore-failed  \
     -cJf \
-    "${BASE_COLLECTION_PATH}/must-gather.tar.xz" "${BASE_COLLECTION_PATH}" || true
+    "${archive}" "${BASE_COLLECTION_PATH}" || true
+
+echo "The ${archive} now can be attached to the support case."
+
+if [[ ${DELETE_AFTER_COMPRESSION} -eq 1 ]]; then
+    find "${BASE_COLLECTION_PATH}" \
+        -mindepth 1 -not -path "*must-gather.tar.xz*" -delete
+fi


### PR DESCRIPTION
This patch adds a step at the end of the gathering to produce an
additional single archive of the whole gathered content.

Use case: I need to grep across pod logs with a request ID so I need to
download the content of the gathering. However the content is
in a lot of small files causing that a recursive wget takes tens of
minutes to finish and probably generates excess load on the log server.

* COMPRESSED_PATH env var can be used to define where to store the
archive created. By default the archive is stored in the root of
the gather directory
* DELETE_AFTER_COMPRESSION env var can be used to define whether the
uncompressed files are deleted after the compression is done. By
default the uncompressed files are also kept. If DELETE_AFTER_COMPRESSION
is set to 1 then the files are deleted.
