### PR TITLE
SOS OCP: Add crypto plugin

### DIFF
--- a/collection-scripts/gather_sos
+++ b/collection-scripts/gather_sos
@@ -40,7 +40,7 @@ else
 fi
 
 # Default to some plugins if SOS_ONLY_PLUGINS is not set
-SOS_ONLY_PLUGINS="${SOS_ONLY_PLUGINS-block,cifs,crio,devicemapper,devices,iscsi,lvm2,memory,multipath,nfs,nis,nvme,podman,process,processor,selinux,scsi,udev,logs}"
+SOS_ONLY_PLUGINS="${SOS_ONLY_PLUGINS-block,cifs,crio,devicemapper,devices,iscsi,lvm2,memory,multipath,nfs,nis,nvme,podman,process,processor,selinux,scsi,udev,logs,crypto}"
 if [[ -n "$SOS_ONLY_PLUGINS" ]]; then
     SOS_LIMIT="--only-plugins $SOS_ONLY_PLUGINS"
 fi


### PR DESCRIPTION
Add the `crypto` plugin to the list of plugins gathered by the SOS report on the OCP nodes.

This is necessary for example to gather FIPS enabled status on the nodes.

There's no need to do anything for EDPM nodes because we gather the `system` profile there and the `crypto` plugin is part of that profile.