### PR TITLE
Gather glance task information

### DIFF
--- a/collection-scripts/gather_services_status
+++ b/collection-scripts/gather_services_status
@@ -50,6 +50,9 @@ get_status() {
     "octavia")
         get_octavia_status
         ;;
+    "glance")
+        get_glance_status
+        ;;
     *) ;;
     esac
 }
@@ -178,6 +181,13 @@ get_octavia_status() {
     done;
 
     run_bg ${BASH_ALIASES[os]} loadbalancer provider list '>' "$OCTAVIA_PATH"/provider_list
+}
+
+# Glance service gathering - task
+get_glance_status() {
+    local GLANCE_PATH="$BASE_COLLECTION_PATH/ctlplane/glance"
+    mkdir -p "$GLANCE_PATH"
+    run_bg ${BASH_ALIASES[os]} image task list '>' "$GLANCE_PATH"/task_list
 }
 
 # first we gather generic status of the openstack ctlplane


### PR DESCRIPTION
This patch set's up the glance directory for service info gathering.
It also adds the task list which tells us about the status of import operations.

Future work:
In future, it would be useful to add stores info which tells us about configured
backends and their properties but it is not currently available in openstackclient.