### PR TITLE
Merge mustgather-approvers group into openstack-approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 approvers:
   - ci-approvers
-  - mustgather-approvers
   - openstack-approvers
 
 reviewers:
   - ci-approvers
-  - mustgather-approvers
   - openstack-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,9 +1,6 @@
 # See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
 
 aliases:
-  mustgather-approvers:
-  - fmount
-  - Akrog
   ci-approvers:
   - lewisdenny
   - frenzyfriday
@@ -14,3 +11,6 @@ aliases:
     - gibizer
     - olliewalsh
     - stuggi
+    - fmount
+    - Akrog
+    - juliakreger


### PR DESCRIPTION
Merge the original list of project approvers with the larger openstack approvers list and adds juliakreger to approvers list.