### PR TITLE
[18.0.0 proposed] - Do not try to get logs from non existent pods

### DIFF
--- a/collection-scripts/gather_ctlplane_resources
+++ b/collection-scripts/gather_ctlplane_resources
@@ -62,14 +62,15 @@ function gather_ctlplane_resources {
     run_bg /usr/bin/oc -n "${NS}" get network-attachment-definitions -o yaml '>' "${NAMESPACE_PATH}/${NS}/nad.log"
 
     # We make a single request to get lines in the form <pod> <container> <previous_log>
+    # mark pods that are in Pending state (they won't have
+    # a status.containerStatuses field) with a null container name
     data=$(oc -n "${NS}" get pods -o json | jq -r '
       .items[] |
       .metadata.name as $pod |
-      .status.containerStatuses[] |
+      .status.containerStatuses[]? // null |
       "\($pod) \(.name) \(.lastState | if .terminated then true else false end)"
     ')
     while read -r pod container previous; do
-        echo "Dump logs for ${container} from ${pod} pod";
         pod_dir="${NAMESPACE_PATH}/${NS}/pods/${pod}"
         log_dir="${pod_dir}/logs"
         if [ ! -d "$log_dir" ]; then
@@ -77,7 +78,10 @@ function gather_ctlplane_resources {
             # describe pod
             run_bg oc -n "$NS" describe pod "$pod" '>' "${pod_dir}/${pod}-describe"
         fi
-        run_bg oc -n "$NS" logs "$pod" -c "$container" '>' "${log_dir}/${container}.log"
+        if [ -n "${container}" ] && [ "${container}" != "null"  ]; then
+            echo "Dump logs for ${container} from ${pod} pod";
+            run_bg oc -n "$NS" logs "$pod" -c "$container" '>' "${log_dir}/${container}.log"
+        fi
         if [[ "$previous" == true ]]; then
             run_bg oc -n "$NS" logs "$pod" -c "$container" --previous '>' "${log_dir}/${container}-previous.log";
         fi

--- a/collection-scripts/gather_ctlplane_resources
+++ b/collection-scripts/gather_ctlplane_resources
@@ -61,9 +61,14 @@ function gather_ctlplane_resources {
     run_bg /usr/bin/oc -n "${NS}" get pvc '>' "${NAMESPACE_PATH}/${NS}/pvc.log"
     run_bg /usr/bin/oc -n "${NS}" get network-attachment-definitions -o yaml '>' "${NAMESPACE_PATH}/${NS}/nad.log"
 
-    # We make a single request to get lines in the form <pod> <container> <crash_status>
-    data=$(oc -n "$NS" get pod -o go-template='{{range $indexp,$pod := .items}}{{range $index,$element := $pod.status.containerStatuses}}{{printf "%s %s" $pod.metadata.name $element.name}} {{ if ne $element.lastState.terminated nil }}{{ printf "%s" $element.lastState.terminated }}{{ end }}{{ printf "\n"}}{{end}}{{end}}')
-    while read -r pod container crash_status; do
+    # We make a single request to get lines in the form <pod> <container> <previous_log>
+    data=$(oc -n "${NS}" get pods -o json | jq -r '
+      .items[] |
+      .metadata.name as $pod |
+      .status.containerStatuses[] |
+      "\($pod) \(.name) \(.lastState | if .terminated then true else false end)"
+    ')
+    while read -r pod container previous; do
         echo "Dump logs for ${container} from ${pod} pod";
         pod_dir="${NAMESPACE_PATH}/${NS}/pods/${pod}"
         log_dir="${pod_dir}/logs"
@@ -73,7 +78,7 @@ function gather_ctlplane_resources {
             run_bg oc -n "$NS" describe pod "$pod" '>' "${pod_dir}/${pod}-describe"
         fi
         run_bg oc -n "$NS" logs "$pod" -c "$container" '>' "${log_dir}/${container}.log"
-        if [[ -n "$crash_status" ]]; then
+        if [[ "$previous" == true ]]; then
             run_bg oc -n "$NS" logs "$pod" -c "$container" --previous '>' "${log_dir}/${container}-previous.log";
         fi
     done <<< "$data"


### PR DESCRIPTION
This patch fixes the current issue related to the fact that we try to get logs from pods that are not present in the namespace. This is caused by the fact that the crash_status variable is sometimes not predictable and an output made by many strings is produced. We only need to know if the Pod was terminated, and get the -previous log, but we don't care about the reason of the crash. In addition, given the complexity generated by go-template, we moved the data processing to json and jq, as it results easy to read and maintain.
However, if a pod is in Pending state and has no 'status.containerStatus' field, the `jq` command crashes, and we get no logs. This change also skips collecting logs for these pods, while still calling `oc describe`.

Jira: [OSPRH-8197](https://issues.redhat.com/browse/OSPRH-8197)