### PR TITLE
Add version file to the data collected with openstack-must-gather

### DIFF
--- a/collection-scripts/gather_run
+++ b/collection-scripts/gather_run
@@ -65,6 +65,10 @@ wait_bg
 # Create rotated log symlinks after everything else has finished
 rotated_logs_symlinks
 
+# Store version of the must-gather tool first
+source "${DIR_NAME}/gather_version"
+log_version
+
 # The path to store the compressed result
 export COMPRESSED_PATH=${COMPRESSED_PATH:-"${BASE_COLLECTION_PATH}"}
 # whether to delete or keep the uncompressed files.

--- a/collection-scripts/gather_version
+++ b/collection-scripts/gather_version
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# load shared functions and data when not sourced
+if [[ -z "$DIR_NAME" ]]; then
+    CALLED=1
+    DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+    source "${DIR_NAME}/common.sh"
+fi
+
+function log_version() {
+    echo "openstack-k8s-operators/openstack-must-gather"> "${BASE_COLLECTION_PATH}/version"
+    ocp_version="0.0.0-unknown"
+    if [[ -n ${OS_GIT_VERSION} ]]; then
+        ocp_version="${OS_GIT_VERSION}"
+    fi
+    echo ${ocp_version} >> "${BASE_COLLECTION_PATH}/version"
+}
+
+if [[ $CALLED -eq 1 ]]; then
+    log_version
+fi


### PR DESCRIPTION
This is in align with must-gather guidelines [1] and will much easier to discover automatically archive data context by the insights and ocp_ccx plugin.

[1] https://github.com/openshift/must-gather/blob/master/must-gather.md#must-gather-images

Related: #[OSPRH-11237](https://issues.redhat.com//browse/OSPRH-11237)
Closes: #[OSPRH-13336](https://issues.redhat.com//browse/OSPRH-13336)