### PR TITLE
Add OS_GIT_VERSION to the openstack-must-gather build system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM quay.io/openshift/origin-must-gather:4.15.0 as builder
 
 FROM quay.io/centos/centos:stream9
 
+ARG OS_GIT_VERSION
+
 RUN dnf update -y && dnf install jq xz rsync python3-pyyaml openssh-clients -y && dnf clean all
 
 COPY --from=builder /usr/bin/oc /usr/bin/oc
@@ -14,6 +16,10 @@ COPY collection-scripts/* /usr/bin/
 
 # Copy the python script used to mask sensitive data
 COPY pyscripts/mask.py /usr/bin/
+
+# Set openstack-must-gather image version based on
+# the current git info
+ENV OS_GIT_VERSION=${OS_GIT_VERSION}
 
 # Entrypoint not used when calling `oc adm must-gather`
 ENTRYPOINT /usr/bin/gather

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 IMAGE_REGISTRY ?= quay.io/openstack-k8s-operators
 IMAGE_TAG ?= latest
 
+OS_GIT_COMMIT := $(shell git rev-parse --short "HEAD^{commit}")
+OS_GIT_BRANCH := $(shell git rev-parse  --abbrev-ref HEAD)
+OS_GIT_COMMIT_COUNT := $(shell git rev-list HEAD --count)
+OS_GIT_VERSION := $(OS_GIT_BRANCH)-$(OS_GIT_COMMIT_COUNT)-g$(OS_GIT_COMMIT)
+
+BUILD_ARGS ?= --build-arg OS_GIT_VERSION=${OS_GIT_VERSION}
+
 check-image: ## Check if the MUST_GATHER_IMAGE variable is set
 ifndef MUST_GATHER_IMAGE
 	$(error MUST_GATHER_IMAGE is not set.)
@@ -15,7 +22,7 @@ pytest: ## Run sanity check against python scripts in pydir
 	tox -c pyscripts/tox.ini
 
 podman-build: check-image ## build the must-gather image
-	podman build -t ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG} .
+	podman build -t ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG} ${BUILD_ARGS} .
 
 podman-push: check-image ## push the must-gather image to the image registry
 	podman push ${IMAGE_REGISTRY}/${MUST_GATHER_IMAGE}:${IMAGE_TAG}

--- a/README.md
+++ b/README.md
@@ -236,6 +236,35 @@ The targets for `make` are as follows:
 - `podman-build`: builds the must-gather image
 - `podman-push`:  pushes an already-built `must-gather` image
 
+As per the [must-gather
+guidelines](https://github.com/openshift/must-gather/blob/master/must-gather.md#must-gather-images),
+when a must-gather image is built, a `OS_GIT_VERSION` environment variable is
+set within the image in the form `major.minor.micro.qualifier`, so that
+programmatic analysis can be developed.
+For OpenStack must-gather, instad, the version is created starting from the
+last commit, and it creates a qualifier based on the following commands:
+
+```bash
+OS_GIT_COMMIT=$(git rev-parse --short "HEAD^{commit}")
+OS_GIT_BRANCH=$(git rev-parse  --abbrev-ref HEAD)
+OS_GIT_COMMIT_COUNT=$(git rev-list HEAD --count)
+OS_GIT_VERSION=$(OS_GIT_BRANCH)-$(OS_GIT_COMMIT_COUNT)-g$(OS_GIT_COMMIT)
+```
+The resulting format is in the form: `<branch>-<number-of-commits>-g<commit-hash>`
+
+For example, if you are on `18.0-FR2` branch, a potential output might look
+like:
+
+```
+18.0-FR2-165-g1234567
+```
+
+Where:
+
+- 18.0-FR2 is the current branch
+- The middle number (165) is how many commits are present in the branch
+- g1234567 is the abbreviated commit hash
+
 ### Debugging container
 
 One possible workflow that can be used for development is to run the openstack


### PR DESCRIPTION
As per the guidelines [1], a `must-gather` image must produce a `version` file that indicates the **product** and the **version**, following the `major.minor.micro.qualifier` approach. By doing this is possible to integrate it with other tools that need this information to process the associated data.
Patch [2] produces a `version` file as part of the `must-gather` execution, while here both the `Makefile` and the `Containerfile` are modified to support this new `ENV` var.
Version is produced in the form `<branch>-<commit_count>-g<commit>`, because as per the `openstack-k8s-operators` branching model tags are not used to indentify a particular release.

Related: #[OSPRH-11237](https://issues.redhat.com//browse/OSPRH-11237)
Related: #[OSPRH-13336](https://issues.redhat.com//browse/OSPRH-13336)

[1] https://github.com/openshift/must-gather/blob/master/must-gather.md#must-gather-images
[2] https://github.com/openstack-k8s-operators/openstack-must-gather/pull/81