### PR TITLE
Gather NodeSet related secrets

### DIFF
--- a/collection-scripts/gather_secrets
+++ b/collection-scripts/gather_secrets
@@ -57,5 +57,10 @@ if [[ $CALLED -eq 1 ]]; then
         NS=openstack
     fi
 
+    # Get all related NodeSet screts
+    for nodeset in $(oc get openstackdataplanenodesets -o name | cut -d/ -f2); do
+        get_secrets "$NS" "$nodeset"
+    done
+
     gather_secrets "$NS"
 fi


### PR DESCRIPTION
Gather any NodeSet related secrets, based on the NodeSet name. This
would include the generated inventory as well as the network-data and
user-data secrets that are generated from the OpenStackBaremetalSet for
baremetal provisioning.

Signed-off-by: James Slagle <jslagle@redhat.com>
