### PR TITLE
Gather 'crc_storage' namespace

### DIFF
--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -23,6 +23,7 @@ declare -a DEFAULT_NAMESPACES=(
     "openshift-operators-redhat"
     "openshift-logging"
     "${METALLB_NAMESPACE}"
+    "crc-storage"
 )
 export DEFAULT_NAMESPACES
 


### PR DESCRIPTION
We've changed `make crc_storage` in `install_yamls` to stop using `oc debug` and instead use a k8s `Job` [1].  For debug purposes, it would be useful to gather the resources from the new namespace [2].

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/1039
[2] https://github.com/openstack-k8s-operators/install_yamls/pull/1042