### PR TITLE
Gather imagestream as part of the process

### DIFF
--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -44,6 +44,7 @@ declare resources=(
     "cert"
     "issuer"
     "certificaterequests"
+    "imagestream"
 )
 export resources
 


### PR DESCRIPTION
Other than `buildConfig`, `imageStream` objects are relevant in many use cases (e.g. `hotfix` process). This patch adds this new entity that should be retrieved as part of the `must-gather` execution.

Jira: https://issues.redhat.com/browse/OSPRH-15934