### PR TITLE
Customize support-tools image for disconnected environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ This is the list of available environmental variables:
   gathered data
 - `DELETE_AFTER_COMPRESSION`: 0 or 1. When set to 1 the uncompressed data is
   deleted after the archive is created. Defaulted to 0.
+- `SUPPORT_TOOLS`: The OpenShift support-tools container image. It allows to
+  override the image location for disconnected environments.
 
 ### Inspect gathered data
 

--- a/collection-scripts/gather_sos
+++ b/collection-scripts/gather_sos
@@ -46,6 +46,7 @@ if [[ -n "$SOS_ONLY_PLUGINS" ]]; then
 fi
 
 TMPDIR=/var/tmp/sos-osp
+SUPPORT_TOOLS=${SUPPORT_TOOLS:-"registry.redhat.io/rhel9/support-tools"}
 
 ###############################################################################
 # SOS GATHERING
@@ -75,7 +76,7 @@ gather_node_sos () {
           rm -rf \"${TMPDIR}\" && \
           mkdir -p \"${TMPDIR}\" && \
           sudo podman rm --force toolbox-osp;  \
-          sudo --preserve-env podman pull --authfile /var/lib/kubelet/config.json registry.redhat.io/rhel9/support-tools && \
+          sudo --preserve-env podman pull --authfile /var/lib/kubelet/config.json $SUPPORT_TOOLS && \
           toolbox sos report --batch --all-logs $SOS_LIMIT --tmp-dir=\"${TMPDIR}\" && \
           if [[ \"\$(ls /var/log/pods/*/{*.log.*,*/*.log.*} 2>/dev/null)\" != '' ]]; then tar --ignore-failed-read --warning=no-file-changed -cJf \"${TMPDIR}/podlogs.tar.xz\" --transform 's,^,podlogs/,' /var/log/pods/*/{*.log.*,*/*.log.*} || true; fi"
 


### PR DESCRIPTION
In disconnected environments it might happen that we're not able to reach the `support-tools` default public registry. With this patch we add an environment variable to customize the support-tools container image and point to an arbitrary mirror.