### PR TITLE
Collect NodeNetworkState

### DIFF
--- a/collection-scripts/gather_network
+++ b/collection-scripts/gather_network
@@ -9,19 +9,25 @@ fi
 
 # get nncp
 mkdir -p "${BASE_COLLECTION_PATH}/network/nncp"
-for iface in $(oc get nncp -o custom-columns=":metadata.name"); do
+for iface in $(oc get nncp -o custom-columns=".NAME:metadata.name" --no-headers); do
     run_bg /usr/bin/oc get nncp "$iface" -o yaml '>' "${BASE_COLLECTION_PATH}/network/nncp/$iface.log";
 done
 
 # get nnce
 mkdir -p "${BASE_COLLECTION_PATH}/network/nnce"
-for iface in $(oc get nnce -o custom-columns=":metadata.name"); do
+for iface in $(oc get nnce -o custom-columns=".NAME:metadata.name" --no-headers); do
     run_bg /usr/bin/oc get nnce "$iface" -o yaml '>' "${BASE_COLLECTION_PATH}/network/nnce/$iface.log";
+done
+
+# get nns
+mkdir -p "${BASE_COLLECTION_PATH}/network/nns"
+for iface in $(oc get nns -o custom-columns=".NAME:metadata.name" --no-headers); do
+    run_bg /usr/bin/oc get nns "$iface" -o yaml '>' "${BASE_COLLECTION_PATH}/network/nns/$iface.log";
 done
 
 # get ipaddresspools
 mkdir -p "${BASE_COLLECTION_PATH}/network/ipaddresspools"
-for ipadd in $(oc -n "${METALLB_NAMESPACE}" get ipaddresspools -o custom-columns=":metadata.name"); do
+for ipadd in $(oc -n "${METALLB_NAMESPACE}" get ipaddresspools -o custom-columns=".NAME:metadata.name" --no-headers); do
     run_bg /usr/bin/oc -n "${METALLB_NAMESPACE}" get ipaddresspools "$ipadd" -o yaml '>' "${BASE_COLLECTION_PATH}/network/ipaddresspools/$ipadd.log";
 done
 


### PR DESCRIPTION
A `NodeNetworkState` object exists on every node in the cluster. This object is periodically updated and captures the state of the network for that node.
This patch updates the `gather_network` script and adds `nns` to the list of captured resources.
It also fixes a small issue in the other `oc` calls to prevent an empty line being printed.

Jira: https://issues.redhat.com/browse/OSPRH-16785