### PR TITLE
Make mask.py more resilient to unexpected data formats

### DIFF
--- a/pyscripts/tests/samples/secret4_no_dict.yaml
+++ b/pyscripts/tests/samples/secret4_no_dict.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+data:
+  "username = This would break the tool as it's not a dict"
+kind: Secret
+type: Opaque

--- a/pyscripts/tests/samples/secret5_no_utf-8_encoded.yaml
+++ b/pyscripts/tests/samples/secret5_no_utf-8_encoded.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  one: "cmFi22"
+  two: "YW"
+  correct: YWJjZGVmCg==
+metadata:
+  name: service-config-data
+  namespace: openstack
+type: Opaque


### PR DESCRIPTION
We're here making the script not failing the whole process when encountering problems while masking.
Now non-dict values and utf-8 codec uncode errors