### PR TITLE
Add per namespace database dump and cell db filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ This is the list of available environmental variables:
 - `OPENSTACK_DATABASES`: comma separated list of OpenStack databases that should
   be dumped. It is possible to set it to `ALL` and dump all databases. By default
   this env var is unset, hence the database dump is skipped.
+- `FILTER_DB_CELLS`: When set to `true`, excludes cell databases from the dump.
+   Default: `false` (cell databases are included).
 - `ADDITIONAL_NAMESPACES`: comma separated list of additional namespaces where
   we want to gather the associated resources.
 - `DO_NOT_MASK`: This is an option for **CI only** purposes. It's set to 0 by

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -8,7 +8,6 @@ export OSP_OPERATORS_NS="${OSP_OPERATORS_NS-openstack-operators}"
 # This option is used for CI purposes and
 # is enabled by default
 export SOS_DECOMPRESS=${SOS_DECOMPRESS:-1}
-
 export BASE_COLLECTION_PATH="${BASE_COLLECTION_PATH:-/must-gather}"
 export SOS_PATH="${BASE_COLLECTION_PATH}/sos-reports"
 export SOS_PATH_NODES="${SOS_PATH}/_all_nodes"

--- a/collection-scripts/gather_db
+++ b/collection-scripts/gather_db
@@ -17,7 +17,27 @@ function dump_db {
     local dbpass="$3"
     local dbname="$4"
     local dump="${4:-openstack_databases}"
-    run_bg /usr/bin/oc -n $ns rsh -c galera $dbpod mysqldump -uroot -p$dbpass $DB_OPT $dbname > "$DB_DUMP"/$dump.sql
+    # skip the service db dump if it does not exist on the current $dbpod
+    if ! /usr/bin/oc exec -n "$ns" "$dbpod" -- mysql -u root -p"$dbpass" -e "USE $dbname;" 2>/dev/null; then
+        echo "Database $dbname does not exist on $dbpod, skipping"
+        return
+    fi
+    # database dump in dbs/<namespace>/<galera_pod>-<service>.sql path
+    run_bg /usr/bin/oc -n $ns rsh -c galera $dbpod mysqldump -uroot -p$dbpass $DB_OPT $dbname > "$DB_DUMP"/"$ns"/$dbpod-$dump.sql
+}
+
+# Select the (first) galera pod for each deployment, and exclude gallera-cellX
+# when FILTER_DB_CELLS is set to true.
+# Note: this parameter is false by default, so we usually include cell dbs
+function get_dbpod() {
+  local namespace="$1"
+  local labels="app=galera,apps.kubernetes.io/pod-index=0"
+  local cmd="oc -n $namespace get pod -l $labels --no-headers -o=custom-columns=NAME:.metadata.name"
+  if [[ "${FILTER_DB_CELLS}" == "true" ]]; then
+      cmd="$cmd | grep -v cell"
+  fi
+  cmd="$cmd | tr '\n' ' '"
+  eval "$cmd"
 }
 
 # If unset or an empty string return/exit
@@ -28,26 +48,35 @@ if [ "${OPENSTACK_DATABASES-unset}" = "unset" ] || [[ -z "${OPENSTACK_DATABASES}
     return
 fi
 
+if [ "${FILTER_DB_CELLS-unset}" = "unset" ] || [[ -z "${FILTER_DB_CELLS}" ]]; then
+    # do not skip cells db if not explicitly set
+    FILTER_DB_CELLS="false"
+fi
+
 # Create the db_dump directory in the BASE_COLLECTION_PATH
 mkdir -p "$DB_DUMP"
 data=$(/usr/bin/oc get openstackcontrolplane --all-namespaces -o go-template='{{range $ins,$service := .items}}{{printf "%s %s\n" $service.metadata.namespace $service.spec.secret}}{{end}}')
 while read -r namespace secret; do
     [[ -z "$namespace" || -z "$secret" ]] && break
-    # get the pwd used to run mysqldump from the galera pod
+    mkdir -p "$DB_DUMP/$namespace"
+    # get the pwd used to run mysqldump from the galera pod in the current namespace
     dbpass=$(/usr/bin/oc get -n $namespace secret/"$secret" -o go-template='{{ index .data "AdminPassword" | base64decode }}')
-    # select the (first) galera pod (and exclude the galera-cellX database services)
-    dbpod="$(/usr/bin/oc -n $namespace get pod -l app=galera --no-headers -o=custom-columns=NAME:.metadata.name | grep -v cell | tr '\n' ' ' | awk '{print $1}')"
-    if [[ "$OPENSTACK_DATABASES" == "ALL" ]]; then
-        DB_OPT="$DB_OPT --all-databases"
-        # dump all databases
-        dump_db "$dbpod" "$namespace" "$dbpass"
-    else
-        # Convert the database list to an array
-        IFS=',' read -r -a OPENSTACK_DATABASES <<< "$OPENSTACK_DATABASES"
-        # for each service dump the associated database (if exists)
-        for service in "${OPENSTACK_DATABASES[@]}"; do
-            dump_db "$dbpod" "$namespace" "$dbpass" "$service"
-        done
-    fi
+    # get the list of galera pods in the current namespace
+    dbpods="$(get_dbpod $namespace)"
+    for dbinst in $dbpods; do
+        if [[ "$OPENSTACK_DATABASES" == "ALL" ]]; then
+            DB_OPT="$DB_OPT --all-databases"
+            # dump all databases
+            dump_db "$dbinst" "$namespace" "$dbpass"
+        else
+            # Convert the database list to an array of services that we
+            # iterate to selectively dump each of them
+            IFS=',' read -r -a OPENSTACK_DBS <<< "$OPENSTACK_DATABASES"
+            # for each service dump the associated database (if exists)
+            for service in "${OPENSTACK_DBS[@]}"; do
+                dump_db "$dbinst" "$namespace" "$dbpass" "$service"
+            done
+        fi
+    done
 done <<< "$data"
 [[ $CALLED -eq 1 ]] && wait_bg


### PR DESCRIPTION
We currently filter `cellX` databases due to the hardcoded `| grep cell`.
This prevents collecting information from the `nova cells` dedicated `galera` instances.
This patch improves this aspect and provides a `FILTER_DB_CELLS` `env var` set to `false` by default.
By doing this we're able to keep backward compatibility with the previous behavior, but also do not always exclude cells `DBs`.
However, `OPENSTACK_DATABASES` `env var` is `global`, so the `dump_db` function is improved to check whether a service is present or not, and gracefully skip the database dump if it is not found in the current `galera` instance.
Because the main loop iterates over the namespaces (we run a `oc get openstackcontrolplane --all-namespaces ...`), the databases dumps are now collected in a `per-namaspace` path like the following: `<must-gather>/dbs/<namespace>/<galera_pod>-<service>.sql`. 
This is valid for both `--all-databases` and selective dumps.

Jira: https://issues.redhat.com/browse/OSPRH-19553