### PR TITLE
Update cinder gmr path

### DIFF
--- a/collection-scripts/gather_trigger_gmr
+++ b/collection-scripts/gather_trigger_gmr
@@ -44,7 +44,7 @@ cinder_trigger_gmr() {
         podname="${line% *}"
         svctype="${line##* }"
         [ "${svctype}" == '<none>' ] && continue
-        run_bg $oce $podname -c $svctype -- touch /etc/cinder
+        run_bg $oce $podname -c $svctype -- touch /var/lib/cinder
     done <<< "$svcs"
 }
 


### PR DESCRIPTION
With patch [1] the path used by `oslo_reports` to trigger `cinder` `gmr` has been updated.
This patch reflects the change provided in the cinder-operator that is caused by the root removal patch series.

[1] https://github.com/openstack-k8s-operators/cinder-operator/pull/544

Jira: https://issues.redhat.com/browse/OSPRH-17882