### PR TITLE
Add 'oc describe node' output

### DIFF
--- a/collection-scripts/gather_nodes
+++ b/collection-scripts/gather_nodes
@@ -9,6 +9,7 @@ fi
 mkdir -p "${NODES_COLLECTION_PATH}"
 for node in $(/usr/bin/oc get nodes -o custom-columns=NAME:.metadata.name --no-headers); do
     run_bg /usr/bin/oc get nodes "${node}" -o yaml '>' "${NODES_COLLECTION_PATH}/${node}.yaml"
+    run_bg /usr/bin/oc describe nodes "${node}" '>' "${NODES_COLLECTION_PATH}/${node}.describe"
 done
 
 [[ $CALLED -eq 1 ]] && wait_bg


### PR DESCRIPTION
Correct me if I'm wrong, but it seems like the default `must-gather` from OpenShift does not include `oc describe node` output, nor does our version.  If that's the case, we should include it, as it provides resource usage data that could be helpful in debugging.