### PR TITLE
Update ci-approvers in OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,9 +2,10 @@
 
 aliases:
   ci-approvers:
-  - lewisdenny
-  - frenzyfriday
-  - viroel
+  - danpawlik
+  - amartyasinha
+  - brjackma
+  - bshewale
   openstack-approvers:
     - abays
     - dprince


### PR DESCRIPTION
Adds current members from CI team to ci-approvers alias.