### PR TITLE
Collect OCP release info and clusterversion

### DIFF
--- a/collection-scripts/gather_ocp_version
+++ b/collection-scripts/gather_ocp_version
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [[ -z "$DIR_NAME" ]]; then
+    CALLED=1
+    DIR_NAME=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+    source "${DIR_NAME}/common.sh"
+fi
+
+echo "Gathering OCP release info"
+run_bg /usr/bin/oc adm release info '>' "${BASE_COLLECTION_PATH}/ocp_release_info"
+run_bg /usr/bin/oc get clusterversion version -o yaml '>' "${BASE_COLLECTION_PATH}/clusterversion.yaml"
+
+[[ $CALLED -eq 1 ]] && wait_bg

--- a/collection-scripts/gather_run
+++ b/collection-scripts/gather_run
@@ -19,6 +19,9 @@ source "${DIR_NAME}/gather_edpm_sos"
 # logs
 expand_ns
 
+# get OCP release info
+source "${DIR_NAME}/gather_ocp_version"
+
 # Skip namespaced resource collection if OMC mode is enabled (oc adm inspect handles this)
 if [[ "${OMC}" != "true" ]]; then
     # Gather openshift resources


### PR DESCRIPTION
Add gather_ocp_version script that captures `oc adm release info` and the ClusterVersion object.