### PR TITLE
Fix SOS report extraction failure due to tar --one-top-level bug

### DIFF
--- a/collection-scripts/gather_edpm_sos
+++ b/collection-scripts/gather_edpm_sos
@@ -99,8 +99,14 @@ gather_edpm_sos () {
     # if were decompressing the sos report, remove the
     # original sos archive
     if [[ ${SOS_DECOMPRESS} -eq 1 ]]; then
-        tar --one-top-level="${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf ${SOS_PATH_NODES}/sosreport-$node.tar.xz
-        rm "${SOS_PATH_NODES}/sosreport-$node.tar.xz"
+        # Use -C instead of --one-top-level to avoid "Invalid cross-device
+        # link" errors caused by --one-top-level combined with
+        # --strip-components in GNU tar 1.34
+        if tar -C "${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf ${SOS_PATH_NODES}/sosreport-$node.tar.xz; then
+            rm "${SOS_PATH_NODES}/sosreport-$node.tar.xz"
+        else
+            echo "Failed to extract sosreport for ${node}, keeping original archive"
+        fi
     fi
 
     # Ensure write access to the sos reports directories so must-gather rsync doesn't fail

--- a/collection-scripts/gather_sos
+++ b/collection-scripts/gather_sos
@@ -119,8 +119,14 @@ gather_node_sos () {
     # if we are decompressing the sos report, remove the original sos archive
     if [[ ${SOS_DECOMPRESS} -eq 1 ]]; then
         mkdir "${SOS_PATH_NODES}/sosreport-$node"
-        tar -i --one-top-level="${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf "${sos_file}"
-        rm "${sos_file}"
+        # Use -C instead of --one-top-level to avoid "Invalid cross-device
+        # link" errors caused by --one-top-level combined with
+        # --strip-components in GNU tar 1.34
+        if tar -i -C "${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf "${sos_file}"; then
+            rm "${sos_file}"
+        else
+            echo "Failed to extract sosreport for ${node}, keeping original archive"
+        fi
         # Ensure write access to the sos reports directories so must-gather rsync doesn't fail
         chmod +w -R "${SOS_PATH_NODES}/sosreport-$node/"
     fi


### PR DESCRIPTION
## Problem

SOS report extraction fails with `Invalid cross-device link` errors on **all files** when using `--one-top-level` combined with `--strip-components` in GNU tar 1.34 (shipped with RHEL 9). This affects both `gather_sos` (control plane nodes) and `gather_edpm_sos` (EDPM nodes).

All SOS report directories end up empty (0 bytes), and since the original tar.xz is unconditionally deleted after the failed extraction, the data is permanently lost.

## Root Cause

GNU tar 1.34 has a bug where `--one-top-level` combined with `--strip-components` triggers `Invalid cross-device link` errors, even when source and destination are on the same filesystem. This is not a hard link or cross-filesystem issue — it affects all file types (regular files, directories, symlinks).

Verified by testing:
```
# FAILS - 17273 errors, 0 files extracted
tar --one-top-level=/tmp/test --strip-components=1 -Jxf sosreport.tar.xz

# WORKS - 0 errors, 15052 files extracted
tar -C /tmp/test --strip-components=1 -Jxf sosreport.tar.xz
```

## Fix

1. Replace `--one-top-level=DIR` with `-C DIR` in both `gather_sos` and `gather_edpm_sos` — achieves the same result (extract into a specific directory) without the bug
2. Check `tar` exit code before deleting the original archive — if extraction fails, the compressed file is preserved as a fallback

## Testing

Tested on RHEL 9 with GNU tar 1.34:
- **Before fix**: all 4 sosreport directories (3 control plane + 1 EDPM) were empty with 17,000+ `Invalid cross-device link` errors
- **After fix**: 15,052 files extracted successfully (194MB)

## Environment

- OpenShift 4.18.30
- openstack-must-gather image: `registry.redhat.io/rhoso-operators/openstack-must-gather-rhel9:1.0`
- GNU tar 1.34 (RHEL 9)

Closes #131