### PR TITLE
Make rabbitmq-cluster-operator gathering optional

### DIFF
--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -54,7 +54,7 @@ declare resources=(
 export resources
 
 # Global CRD matching function for consistent discovery across all scripts
-# Explictly adding rabbit because its CRD is named with a different domain.
+# Explicitly adding rabbit because its CRD is named with a different domain (rabbitmq-cluster-operator may be optional).
 # Also adding monitoring.rhobs, because telemetry uses observability-operator
 # to deploy a `MonitoringStack` for storing and scraping metrics.
 # Adding grafana.com, observability.openshift.io and logging.openshift.io

--- a/collection-scripts/gather_apiservices
+++ b/collection-scripts/gather_apiservices
@@ -9,7 +9,7 @@ fi
 # Resource list
 apiservices=()
 
-# explicitly adding rabbitmq in the grep because we rely on the rabbitmq-cluster-operator
+# explicitly adding rabbitmq in the grep because the rabbitmq-cluster-operator may be present
 for i in $(/usr/bin/oc get apiservices --all-namespaces | awk '/(openstack|rabbitmq)\.(org|com)/ { print $1 }'); do
     apiservices+=("$i")
 done

--- a/collection-scripts/gather_services_status
+++ b/collection-scripts/gather_services_status
@@ -80,10 +80,14 @@ get_openstack_status() {
 }
 
 # Rabbitmq info gathering -
+# rabbitmq-cluster-operator may not be present, so we skip if no pods are found
 get_rabbitmq_status() {
     local RABBIT_PATH="$BASE_COLLECTION_PATH/ctlplane/rabbitmq"
+    rabbit_instances=$(oc -n "${OSP_NS}" get pods -l "$RABBITMQ_SELECTOR" -o custom-columns=NAME:.metadata.name --no-headers 2>/dev/null)
+    if [ -z "$rabbit_instances" ]; then
+        return
+    fi
     mkdir -p "$RABBIT_PATH"
-    rabbit_instances=$(oc -n "${OSP_NS}" get pods -l "$RABBITMQ_SELECTOR" -o custom-columns=NAME:.metadata.name --no-headers)
     for inst in $rabbit_instances; do
         mkdir -p "$RABBIT_PATH/$inst"
         run_bg oc -n "${OSP_NS}" rsh "$inst" rabbitmqctl status '>' "$RABBIT_PATH"/"$inst"/status


### PR DESCRIPTION
The rabbitmq-cluster-operator may not be deployed in the environment (see openstack-operator PR #1857). Skip rabbitmq status gathering when no rabbitmq pods are found instead of creating empty directories, and update comments to reflect that the operator is optional.