### PR TITLE
fix: correct tar --one-top-level usage in gather_edpm_sos

### DIFF
--- a/collection-scripts/gather_edpm_sos
+++ b/collection-scripts/gather_edpm_sos
@@ -99,7 +99,7 @@ gather_edpm_sos () {
     # if were decompressing the sos report, remove the
     # original sos archive
     if [[ ${SOS_DECOMPRESS} -eq 1 ]]; then
-        tar --one-top-level="${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf ${SOS_PATH_NODES}/sosreport-$node.tar.xz
+        tar -C "${SOS_PATH_NODES}" --one-top-level="sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf "${SOS_PATH_NODES}/sosreport-$node.tar.xz"
         rm "${SOS_PATH_NODES}/sosreport-$node.tar.xz"
     fi
 


### PR DESCRIPTION
The --one-top-level option expects a directory name, not a full path. Split the target into -C for the base directory and --one-top-level for the relative subdirectory name to ensure correct extraction behavior. Also added quoting around the source archive argument.

Made-with: Cursor