### PR TITLE
fix: improve must-gather resilience for SOS and container log collection

### DIFF
--- a/collection-scripts/gather_ctlplane_resources
+++ b/collection-scripts/gather_ctlplane_resources
@@ -69,11 +69,11 @@ function gather_ctlplane_resources {
       .metadata.name as $pod |
       (.status |
         (
-          if has("initContainerStatuses") then .initContainerStatuses[] else empty end |
+          if has("initContainerStatuses") then .initContainerStatuses[] | select(.state | has("running") or has("terminated")) else empty end |
           "\($pod) \(.name) \(has("lastState") and (.lastState | has("terminated"))) true"
         ),
         (
-          if has("containerStatuses") then .containerStatuses[] else empty end |
+          if has("containerStatuses") then .containerStatuses[] | select(.state | has("running") or has("terminated")) else empty end |
           "\($pod) \(.name) \(has("lastState") and (.lastState | has("terminated"))) false"
         )
       )

--- a/collection-scripts/gather_sos
+++ b/collection-scripts/gather_sos
@@ -118,11 +118,13 @@ gather_node_sos () {
 
     # if we are decompressing the sos report, remove the original sos archive
     if [[ ${SOS_DECOMPRESS} -eq 1 ]]; then
-        mkdir "${SOS_PATH_NODES}/sosreport-$node"
-        tar -i --one-top-level="${SOS_PATH_NODES}/sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf "${sos_file}"
-        rm "${sos_file}"
-        # Ensure write access to the sos reports directories so must-gather rsync doesn't fail
-        chmod +w -R "${SOS_PATH_NODES}/sosreport-$node/"
+        if tar -i -C "${SOS_PATH_NODES}" --one-top-level="sosreport-$node" --strip-components=1 --exclude='*/dev/null' -Jxf "${sos_file}"; then
+            rm "${sos_file}"
+            # Ensure write access to the sos reports directories so must-gather rsync doesn't fail
+            chmod +w -R "${SOS_PATH_NODES}/sosreport-$node/"
+        else
+            echo "Failed to decompress SOS report for ${node}, keeping compressed archive"
+        fi
     fi
 
     sleep 1

--- a/collection-scripts/gather_sos
+++ b/collection-scripts/gather_sos
@@ -80,7 +80,7 @@ gather_node_sos () {
           mkdir -p \"${TMPDIR}\" && \
           sudo podman rm --force toolbox-osp;  \
           sudo --preserve-env podman pull --authfile /var/lib/kubelet/config.json $SUPPORT_TOOLS && \
-          toolbox sos report --batch --all-logs $SOS_LIMIT --tmp-dir=\"${TMPDIR}\" && \
+          toolbox sos report --batch --all-logs $SOS_LIMIT --tmp-dir=\"/host${TMPDIR}\" && \
           if [[ \"\$(ls /var/log/pods/*/{*.log.*,*/*.log.*} 2>/dev/null)\" != '' ]]; then tar --ignore-failed-read --warning=no-file-changed -cJf \"${TMPDIR}/podlogs.tar.xz\" --transform 's,^,podlogs/,' /var/log/pods/*/{*.log.*,*/*.log.*} || true; fi"
 
     # shellcheck disable=SC2181

--- a/pyscripts/tox.ini
+++ b/pyscripts/tox.ini
@@ -9,6 +9,7 @@ envlist =
     mypy
     stestr
     pytest
+skip_missing_interpreters = true
 skipsdist = true
 passenv =
   LANG


### PR DESCRIPTION
Fix tar --one-top-level usage in gather_sos to use -C with a relative directory name, matching the fix already applied in gather_edpm_sos (a6cb8e1). The --one-top-level option expects a relative path, not an absolute one, which caused "must use a relative file name" errors.

Make SOS report decompression non-fatal: if tar fails, preserve the compressed archive instead of deleting it and leaving nothing.

Filter out containers in waiting state from log collection in gather_ctlplane_resources. Containers that have never started have no logs, and oc logs errors on them (e.g. "container frr is not valid for pod speaker-*" in MetalLB with FRR-K8s mode).