### PR TITLE
Fix case-insensitive and YAML-colon matching in PlaintextMask

### DIFF
--- a/pyscripts/mask.py
+++ b/pyscripts/mask.py
@@ -55,7 +55,7 @@ MASK_STR = "**********"
 # general and connection regexes are used to match the pattern that should be
 # applied to both Protect keys and connection keys, which is the same thing
 # done in SoS reports
-gen_regex = r'(\w*(%s)\s*=\s*)(.*)' % "|".join(PROTECT_KEYS)
+gen_regex = r'(\w*(%s)\s*[=:]\s*)(.*)' % "|".join(PROTECT_KEYS)
 con_regex = r'((%s)\s*://)(\w*):(.*)(@(.*))' % "|".join(CONNECTION_KEYS)
 
 # In k8s secrets, it's possible to define sensitive information in the form
@@ -215,7 +215,7 @@ class SecretMask():
                 d[k] = ''
                 continue
             # try to match the keys we want to protect in the dict
-            if re.findall(key_regex, k):
+            if re.findall(key_regex, k, re.IGNORECASE):
                 # mask the value of the key entirely
                 masked = MASK_STR
             else:
@@ -318,7 +318,7 @@ class PlaintextMask():
         Handles both single-line and multi-line strings.
         """
         for pattern in regexes:
-            text = re.sub(pattern, r"\1{}".format(MASK_STR), text, flags=re.MULTILINE)
+            text = re.sub(pattern, r"\1{}".format(MASK_STR), text, flags=re.MULTILINE | re.IGNORECASE)
         return text
 
 

--- a/pyscripts/test_mask_plaintext.py
+++ b/pyscripts/test_mask_plaintext.py
@@ -226,6 +226,55 @@ class TestPlaintextMask(unittest.TestCase):
         self.assertNotIn('deeppass123', str(result))
         self.assertNotIn('adminpass', str(result))
 
+    def test_mixed_case_keys(self):
+        """
+        Test that keys with mixed case (e.g. Password, PASSWORD) are masked.
+        """
+        configmap = {
+            'apiVersion': 'v1',
+            'kind': 'ConfigMap',
+            'data': {
+                'config': 'Password=Secret1\nPASSWORD=Secret2\nadmin_Password=Secret3'
+            }
+        }
+        temp_file = self._create_temp_file(configmap)
+
+        PlaintextMask(temp_file).mask()
+
+        result = self._read_sample(temp_file)
+        config = result['data']['config']
+
+        self.assertNotIn('Secret1', config)
+        self.assertNotIn('Secret2', config)
+        self.assertNotIn('Secret3', config)
+        self.assertIn('Password=**********', config)
+        self.assertIn('PASSWORD=**********', config)
+        self.assertIn('admin_Password=**********', config)
+
+    def test_yaml_colon_keys(self):
+        """
+        Test that YAML-style colon-separated keys (e.g. password: value) are masked.
+        """
+        configmap = {
+            'apiVersion': 'v1',
+            'kind': 'ConfigMap',
+            'data': {
+                'config': 'password: mysecret\nusername: admin\nconnection: mysql://u:p@host/db'
+            }
+        }
+        temp_file = self._create_temp_file(configmap)
+
+        PlaintextMask(temp_file).mask()
+
+        result = self._read_sample(temp_file)
+        config = result['data']['config']
+
+        self.assertNotIn('mysecret', config)
+        self.assertNotIn('admin', config)
+        self.assertIn('password: **********', config)
+        self.assertIn('username: **********', config)
+        self.assertIn('connection: **********', config)
+
     def test_sample_files(self):
         """
         Test masking on sample files in tests/samples_plaintext directory


### PR DESCRIPTION
`gen_regex` only matched `=` as the key-value separator, missing YAML-style `key: value` lines. `_applyRegex` was also case-sensitive.
- Broaden `gen_regex` separator from `=` to `[=:]`
- Add `re.IGNORECASE` flag in `_applyRegex` 
- Add tests to cover this enhancement (mixed-case keys and YAML-colon keys)

Jira: https://redhat.atlassian.net/browse/OSPRH-32478