### PR TITLE
Remove AdminPassword from mysqldump command line

### DIFF
--- a/collection-scripts/gather_db
+++ b/collection-scripts/gather_db
@@ -14,16 +14,15 @@ DB_DUMP=${BASE_COLLECTION_PATH}/dbs
 function dump_db {
     local dbpod="$1"
     local ns="$2"
-    local dbpass="$3"
-    local dbname="$4"
-    local dump="${4:-openstack_databases}"
+    local dbname="$3"
+    local dump="${3:-openstack_databases}"
     # skip the service db dump if it does not exist on the current $dbpod
-    if ! /usr/bin/oc exec -n "$ns" "$dbpod" -- mysql -u root -p"$dbpass" -e "USE $dbname;" 2>/dev/null; then
+    if ! /usr/bin/oc exec -n "$ns" "$dbpod" -- mysql -u root -e "USE $dbname;" 2>/dev/null; then
         echo "Database $dbname does not exist on $dbpod, skipping"
         return
     fi
     # database dump in dbs/<namespace>/<galera_pod>-<service>.sql path
-    run_bg /usr/bin/oc -n $ns rsh -c galera $dbpod mysqldump -uroot -p$dbpass $DB_OPT $dbname > "$DB_DUMP"/"$ns"/$dbpod-$dump.sql
+    run_bg /usr/bin/oc -n $ns rsh -c galera $dbpod mysqldump -uroot $DB_OPT $dbname > "$DB_DUMP"/"$ns"/$dbpod-$dump.sql
 }
 
 # Select the (first) galera pod for each deployment, and exclude gallera-cellX
@@ -59,22 +58,20 @@ data=$(/usr/bin/oc get openstackcontrolplane --all-namespaces -o go-template='{{
 while read -r namespace secret; do
     [[ -z "$namespace" || -z "$secret" ]] && break
     mkdir -p "$DB_DUMP/$namespace"
-    # get the pwd used to run mysqldump from the galera pod in the current namespace
-    dbpass=$(/usr/bin/oc get -n $namespace secret/"$secret" -o go-template='{{ index .data "AdminPassword" | base64decode }}')
     # get the list of galera pods in the current namespace
     dbpods="$(get_dbpod $namespace)"
     for dbinst in $dbpods; do
         if [[ "$OPENSTACK_DATABASES" == "ALL" ]] || [[ "$OPENSTACK_DATABASES" == "all" ]]; then
             DB_OPT="$DB_OPT --all-databases"
             # dump all databases
-            dump_db "$dbinst" "$namespace" "$dbpass"
+            dump_db "$dbinst" "$namespace"
         else
             # Convert the database list to an array of services that we
             # iterate to selectively dump each of them
             IFS=',' read -r -a OPENSTACK_DBS <<< "$OPENSTACK_DATABASES"
             # for each service dump the associated database (if exists)
             for service in "${OPENSTACK_DBS[@]}"; do
-                dump_db "$dbinst" "$namespace" "$dbpass" "$service"
+                dump_db "$dbinst" "$namespace" "$service"
             done
         fi
     done


### PR DESCRIPTION
The `galera` `Pod` already has credentials available via `/var/local/my.cnf/mysql_pw_cache.cnf` (injected by `mariadb-operator`), which `mysql/mysqldump` auto-include through the `!includedir` directive in `galera.cnf`. Passing `-p$dbpass` in the command line was redundant and caused the password to appear in the `kube-apiserver` audit log `requestURI` (`oc exec` encodes command `args` as query parameters).

This patch drops the `dbpass` parameter from `dump_db` and the `Secret` fetch from the main loop, letting the in-pod `.cnf` handle authentication.

Jira: https://redhat.atlassian.net/browse/OSPRH-32481