### PR TITLE
Fix gather_sos debug pod race condition and add timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ This is the list of available environmental variables:
   gathered data
 - `DELETE_AFTER_COMPRESSION`: 0 or 1. When set to 1 the uncompressed data is
   deleted after the archive is created. Defaulted to 0.
+- `CMD_TIMEOUT`: Timeout in seconds for general remote-execution commands
+  (`oc rsh`, `oc exec`, `oc cp`, openstack CLI). Prevents individual commands
+  from hanging indefinitely. Defaults to `120`.
+- `SOS_CMD_TIMEOUT`: Timeout in seconds for SOS report generation and download
+  via `oc debug` or SSH. These operations are legitimately slow, so the default
+  is higher. Defaults to `600`.
 - `SUPPORT_TOOLS`: The OpenShift support-tools container image. It allows to
   override the image location for disconnected environments.
 - `OMC`: Controls the directory structure format. Set to `false` to use the legacy

--- a/collection-scripts/common.sh
+++ b/collection-scripts/common.sh
@@ -16,6 +16,20 @@ export SOS_PATH="${BASE_COLLECTION_PATH}/sos-reports"
 export SOS_PATH_NODES="${SOS_PATH}/_all_nodes"
 export METALLB_NAMESPACE=${METALLB_NAMESPACE:-"metallb-system"}
 export RABBITMQ_SELECTOR="app.kubernetes.io/component=rabbitmq"
+# Timeouts (seconds) to prevent commands from hanging indefinitely
+export CMD_TIMEOUT=${CMD_TIMEOUT:-120}
+export SOS_CMD_TIMEOUT=${SOS_CMD_TIMEOUT:-600}
+
+function run_with_timeout {
+    local tout="$1"
+    shift
+    timeout "$tout" "$@"
+    local rc=$?
+    if [[ $rc -eq 124 ]]; then
+        echo "TIMEOUT after ${tout}s: $*" >&2
+    fi
+    return $rc
+}
 export OADP_NS="${OADP_NS-openshift-adp}"
 declare -a DEFAULT_NAMESPACES=(
     "${OSP_NS}"

--- a/collection-scripts/gather_db
+++ b/collection-scripts/gather_db
@@ -17,12 +17,12 @@ function dump_db {
     local dbname="$3"
     local dump="${3:-openstack_databases}"
     # skip the service db dump if it does not exist on the current $dbpod
-    if ! /usr/bin/oc exec -n "$ns" "$dbpod" -- mysql -u root -e "USE $dbname;" 2>/dev/null; then
+    if ! run_with_timeout "$CMD_TIMEOUT" /usr/bin/oc exec -n "$ns" "$dbpod" -- mysql -u root -e "USE $dbname;" 2>/dev/null; then
         echo "Database $dbname does not exist on $dbpod, skipping"
         return
     fi
     # database dump in dbs/<namespace>/<galera_pod>-<service>.sql path
-    run_bg /usr/bin/oc -n $ns rsh -c galera $dbpod mysqldump -uroot $DB_OPT $dbname > "$DB_DUMP"/"$ns"/$dbpod-$dump.sql
+    run_bg run_with_timeout "$CMD_TIMEOUT" /usr/bin/oc -n $ns rsh -c galera $dbpod mysqldump -uroot $DB_OPT $dbname > "$DB_DUMP"/"$ns"/$dbpod-$dump.sql
 }
 
 # Select the (first) galera pod for each deployment, and exclude gallera-cellX

--- a/collection-scripts/gather_edpm_sos
+++ b/collection-scripts/gather_edpm_sos
@@ -55,7 +55,7 @@ if [[ -n "$SOS_EDPM_PLUGINS" ]]; then
 fi
 
 SSH () {
-    ssh -n -i "$key_path" "${username}@${address}" -o StrictHostKeyChecking=accept-new "$@"
+    run_with_timeout "$SOS_CMD_TIMEOUT" ssh -n -i "$key_path" "${username}@${address}" -o StrictHostKeyChecking=accept-new -o ConnectTimeout=30 "$@"
 }
 
 gather_edpm_sos () {

--- a/collection-scripts/gather_services_status
+++ b/collection-scripts/gather_services_status
@@ -8,7 +8,7 @@ if [[ -z "$DIR_NAME" ]]; then
 fi
 
 # shellcheck disable=SC2139  # We want it expanded when defined
-alias os="/usr/bin/oc -n ${OSP_NS} rsh openstackclient openstack "
+alias os="run_with_timeout ${CMD_TIMEOUT} /usr/bin/oc -n ${OSP_NS} rsh openstackclient openstack "
 
 # For each service passed an input, if the associated entry exists,
 # we can call the related function that processes specific service
@@ -90,12 +90,12 @@ get_rabbitmq_status() {
     mkdir -p "$RABBIT_PATH"
     for inst in $rabbit_instances; do
         mkdir -p "$RABBIT_PATH/$inst"
-        run_bg oc -n "${OSP_NS}" rsh "$inst" rabbitmqctl status '>' "$RABBIT_PATH"/"$inst"/status
-        run_bg oc -n "${OSP_NS}" rsh "$inst" rabbitmqctl cluster_status '>' "$RABBIT_PATH"/"$inst"/cluster_status
-        run_bg oc -n "${OSP_NS}" rsh "$inst" rabbitmqctl list_queues '>' "$RABBIT_PATH"/"$inst"/list_queues
-        run_bg oc -n "${OSP_NS}" rsh "$inst" rabbitmqctl list_connections '>' "$RABBIT_PATH"/"$inst"/list_connections
-        run_bg oc -n "${OSP_NS}" rsh "$inst" rabbitmqctl list_policies '>' "$RABBIT_PATH"/"$inst"/list_policies
-        run_bg oc -n "${OSP_NS}" rsh "$inst" rabbitmqctl list_unresponsive_queues '>' "$RABBIT_PATH"/"$inst"/list_unresponsive_queues
+        run_bg run_with_timeout "$CMD_TIMEOUT" oc -n "${OSP_NS}" rsh "$inst" rabbitmqctl status '>' "$RABBIT_PATH"/"$inst"/status
+        run_bg run_with_timeout "$CMD_TIMEOUT" oc -n "${OSP_NS}" rsh "$inst" rabbitmqctl cluster_status '>' "$RABBIT_PATH"/"$inst"/cluster_status
+        run_bg run_with_timeout "$CMD_TIMEOUT" oc -n "${OSP_NS}" rsh "$inst" rabbitmqctl list_queues '>' "$RABBIT_PATH"/"$inst"/list_queues
+        run_bg run_with_timeout "$CMD_TIMEOUT" oc -n "${OSP_NS}" rsh "$inst" rabbitmqctl list_connections '>' "$RABBIT_PATH"/"$inst"/list_connections
+        run_bg run_with_timeout "$CMD_TIMEOUT" oc -n "${OSP_NS}" rsh "$inst" rabbitmqctl list_policies '>' "$RABBIT_PATH"/"$inst"/list_policies
+        run_bg run_with_timeout "$CMD_TIMEOUT" oc -n "${OSP_NS}" rsh "$inst" rabbitmqctl list_unresponsive_queues '>' "$RABBIT_PATH"/"$inst"/list_unresponsive_queues
     done
 }
 
@@ -148,8 +148,8 @@ get_nova_status() {
     mkdir -p "$NOVA_PATH"
     run_bg ${BASH_ALIASES[os]} compute service list '>' "$NOVA_PATH"/service_list
     run_bg ${BASH_ALIASES[os]} hypervisor list '>' "$NOVA_PATH"/hypervisor_list
-    run_bg /usr/bin/oc -n ${OSP_NS} exec -t nova-cell0-conductor-0 -- nova-manage cell_v2 list_cells '>' "$NOVA_PATH"/cell_list
-    run_bg /usr/bin/oc -n ${OSP_NS} exec -t nova-cell0-conductor-0 -- nova-manage cell_v2 list_hosts '>' "$NOVA_PATH"/host_list
+    run_bg run_with_timeout "$CMD_TIMEOUT" /usr/bin/oc -n ${OSP_NS} exec -t nova-cell0-conductor-0 -- nova-manage cell_v2 list_cells '>' "$NOVA_PATH"/cell_list
+    run_bg run_with_timeout "$CMD_TIMEOUT" /usr/bin/oc -n ${OSP_NS} exec -t nova-cell0-conductor-0 -- nova-manage cell_v2 list_hosts '>' "$NOVA_PATH"/host_list
     run_bg ${BASH_ALIASES[os]} aggregate list --long '>' "$NOVA_PATH"/aggregate_list
 }
 
@@ -254,7 +254,7 @@ get_designate_status() {
 
     WORKER=$(oc get pods -l component=designate-worker -o custom-columns=NAME:.metadata.name --no-headers | head -n 1)
     # We can add the --all_pools flag when it is available in openstackclient
-    run_bg /usr/bin/oc -n ${OSP_NS} exec -t ${WORKER} -- designate-manage pool show_config '>' "$DESIGNATE_PATH"/pool_list
+    run_bg run_with_timeout "$CMD_TIMEOUT" /usr/bin/oc -n ${OSP_NS} exec -t ${WORKER} -- designate-manage pool show_config '>' "$DESIGNATE_PATH"/pool_list
 }
 
 # OVN service gathering - database files and status info
@@ -266,7 +266,7 @@ get_ovn_status() {
     local nb_pod="ovsdbserver-nb-0"
     if /usr/bin/oc -n "${OSP_NS}" get pod "${nb_pod}" &>/dev/null; then
         echo "Copying OVN NB database from ${nb_pod}"
-        run_bg /usr/bin/oc cp -n "${OSP_NS}" "${nb_pod}:/etc/ovn/ovnnb_db.db" "${OVN_PATH}/ovnnb_db.db"
+        run_bg run_with_timeout "$CMD_TIMEOUT" /usr/bin/oc cp -n "${OSP_NS}" "${nb_pod}:/etc/ovn/ovnnb_db.db" "${OVN_PATH}/ovnnb_db.db"
     else
         echo "Pod ${nb_pod} not found in namespace ${OSP_NS}, skipping OVN NB database collection"
     fi
@@ -275,7 +275,7 @@ get_ovn_status() {
     local sb_pod="ovsdbserver-sb-0"
     if /usr/bin/oc -n "${OSP_NS}" get pod "${sb_pod}" &>/dev/null; then
         echo "Copying OVN SB database from ${sb_pod}"
-        run_bg /usr/bin/oc cp -n "${OSP_NS}" "${sb_pod}:/etc/ovn/ovnsb_db.db" "${OVN_PATH}/ovnsb_db.db"
+        run_bg run_with_timeout "$CMD_TIMEOUT" /usr/bin/oc cp -n "${OSP_NS}" "${sb_pod}:/etc/ovn/ovnsb_db.db" "${OVN_PATH}/ovnsb_db.db"
     else
         echo "Pod ${sb_pod} not found in namespace ${OSP_NS}, skipping OVN SB database collection"
     fi
@@ -291,10 +291,10 @@ get_ovn_status() {
         echo "Collecting cluster status from NB pod: $pod"
         # Try /etc/ovn first, fallback to /tmp for backward compatibility
         nb_ctl_path="/etc/ovn/ovnnb_db.ctl"
-        if ! /usr/bin/oc -n "${OSP_NS}" rsh "$pod" test -S "$nb_ctl_path" 2>/dev/null; then
+        if ! run_with_timeout "$CMD_TIMEOUT" /usr/bin/oc -n "${OSP_NS}" rsh "$pod" test -S "$nb_ctl_path" 2>/dev/null; then
             nb_ctl_path="/tmp/ovnnb_db.ctl"
         fi
-        run_bg /usr/bin/oc -n "${OSP_NS}" rsh "$pod" ovn-appctl -t "$nb_ctl_path" cluster/status OVN_Northbound > "${OVN_PATH}/cluster-status/nb/${pod}.txt" 2>/dev/null || echo "Failed to collect status from NB pod: $pod"
+        run_bg run_with_timeout "$CMD_TIMEOUT" /usr/bin/oc -n "${OSP_NS}" rsh "$pod" ovn-appctl -t "$nb_ctl_path" cluster/status OVN_Northbound > "${OVN_PATH}/cluster-status/nb/${pod}.txt" 2>/dev/null || echo "Failed to collect status from NB pod: $pod"
     done
 
     # Collect cluster status from all OVN SB pods
@@ -302,10 +302,10 @@ get_ovn_status() {
         echo "Collecting cluster status from SB pod: $pod"
         # Try /etc/ovn first, fallback to /tmp for backward compatibility
         sb_ctl_path="/etc/ovn/ovnsb_db.ctl"
-        if ! /usr/bin/oc -n "${OSP_NS}" rsh "$pod" test -S "$sb_ctl_path" 2>/dev/null; then
+        if ! run_with_timeout "$CMD_TIMEOUT" /usr/bin/oc -n "${OSP_NS}" rsh "$pod" test -S "$sb_ctl_path" 2>/dev/null; then
             sb_ctl_path="/tmp/ovnsb_db.ctl"
         fi
-        run_bg /usr/bin/oc -n "${OSP_NS}" rsh "$pod" ovn-appctl -t "$sb_ctl_path" cluster/status OVN_Southbound > "${OVN_PATH}/cluster-status/sb/${pod}.txt" 2>/dev/null || echo "Failed to collect status from SB pod: $pod"
+        run_bg run_with_timeout "$CMD_TIMEOUT" /usr/bin/oc -n "${OSP_NS}" rsh "$pod" ovn-appctl -t "$sb_ctl_path" cluster/status OVN_Southbound > "${OVN_PATH}/cluster-status/sb/${pod}.txt" 2>/dev/null || echo "Failed to collect status from SB pod: $pod"
     done
 }
 

--- a/collection-scripts/gather_sos
+++ b/collection-scripts/gather_sos
@@ -74,7 +74,7 @@ gather_node_sos () {
     # - Ignore errors on tar since it fails if logs are added while doing the tar as well as if a file doesn't exist
     #   (because the glob has no data or because the file was removed by the log rotation mechanism)
     # - Build LOGS env var to pass tar based on existing files, as tar fails when run with glob that produces no files
-    oc debug "node/$node" -- chroot /host bash \
+    run_with_timeout "$SOS_CMD_TIMEOUT" oc debug "node/$node" -- chroot /host bash \
       -c "echo 'TOOLBOX_NAME=toolbox-osp' > /root/.toolboxrc ; \
           rm -rf \"${TMPDIR}\" && \
           mkdir -p \"${TMPDIR}\" && \
@@ -92,7 +92,7 @@ gather_node_sos () {
     # Wait until we know for sure the debug pod is gone, this is to try to
     # workaround the following failure:
     #   Error from server (BadRequest): container "container-00" in pod debug is waiting to start: ContainerCreating
-    while oc get pod "${node}-debug" 1>/dev/null 2>&1 1>/dev/; do
+    while oc get pod "${node}-debug" 1>/dev/null 2>&1; do
         sleep 1
     done
     sleep 1
@@ -106,7 +106,7 @@ gather_node_sos () {
     sos_file="${SOS_PATH_NODES}/sosreport-$node-UntarWithArg-i.tar.xz"
     download_logs="${SOS_PATH_NODES}/sosreport-$node.tar.xz-download.logs"
     # Add "--loglevel 6" to help debug in case there's a failure
-    oc debug --loglevel 6 "node/$node" -- bash -c "cat \"/host${TMPDIR}/\"*.tar.xz" 2> "${download_logs}" 1> "${sos_file}"
+    run_with_timeout "$SOS_CMD_TIMEOUT" oc debug --loglevel 6 "node/$node" -- bash -c "cat \"/host${TMPDIR}/\"*.tar.xz" 2> "${download_logs}" 1> "${sos_file}"
 
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
@@ -129,7 +129,7 @@ gather_node_sos () {
 
     sleep 1
     # Delete the tar.xz file from the remote node
-    oc debug "node/$node" -- chroot /host bash -c "rm -rf $TMPDIR"
+    run_with_timeout "$CMD_TIMEOUT" oc debug "node/$node" -- chroot /host bash -c "rm -rf $TMPDIR"
 }
 
 

--- a/collection-scripts/gather_trigger_gmr
+++ b/collection-scripts/gather_trigger_gmr
@@ -12,7 +12,7 @@ if [[ -z "$DIR_NAME" ]]; then
     source "${DIR_NAME}/common.sh"
 fi
 
-oc="/usr/bin/oc -n ${OSP_NS} "
+oc="run_with_timeout $CMD_TIMEOUT /usr/bin/oc -n ${OSP_NS} "
 oce="$oc exec "
 
 


### PR DESCRIPTION
The while loop in `gather_sos` that waits for a previous debug pod to terminate had an erroneous redirect `(1>/dev/;)` that caused the loop to never execute, creating a race condition where the next `oc debug` call could fail with "container in pod debug is waiting to start: ContainerCreating".

More critically, no `oc debug/rsh/exec/cp`, SSH, or `openstack` CLI command anywhere in the must-gather had a timeout. A single hanging command (e.g. stalled image pull, unresponsive pod, unreachable service) would block the entire must-gather until the external `oc adm must-gather --timeout` killed it — collecting nothing.

Add two configurable timeout tiers via environment variables:
- `CMD_TIMEOUT` (default 120s): `oc rsh`, `oc exec`, `oc cp`, `openstack` CLI
- `SOS_CMD_TIMEOUT` (default 600s): SOS report `oc debug` and SSH ops

Wrap all remote-execution commands with `timeout` in `gather_sos`, `gather_edpm_sos`, `gather_trigger_gmr`, `gather_services_status`, and `gather_db`. Fast local commands (`oc get`, `oc describe`) are unchanged.

Co-Authored-By: Andrew Bays <abays@redhat.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>