### PR TITLE
Fix double YAML round-trip in ConfigMap splitting

### DIFF
--- a/pyscripts/cmaps.py
+++ b/pyscripts/cmaps.py
@@ -14,10 +14,9 @@ from pathlib import Path
 
 # Import mask module for applying masking
 try:
-    from mask import mask_resource
+    from mask import mask_data
 except ImportError:
-    # Fallback if mask module not found
-    mask_resource = None
+    mask_data = None
 
 
 def split_configmaps(input_file, output_dir='configmaps', apply_mask=False):
@@ -50,6 +49,9 @@ def split_configmaps(input_file, output_dir='configmaps', apply_mask=False):
     configmaps = data.get('items', [])
     created_files = []
 
+    total = len(configmaps)
+    print(f"Processing {total} ConfigMaps from {input_file}", flush=True)
+
     # Process each ConfigMap
     for i, cm in enumerate(configmaps, 1):
         # Extract metadata
@@ -60,21 +62,20 @@ def split_configmaps(input_file, output_dir='configmaps', apply_mask=False):
         filename = f"{name}.yaml"
         filepath = output_path / filename
 
-        # Write the ConfigMap to its own file
-        with open(filepath, 'w') as f:
-            yaml.dump(cm, f, default_flow_style=False, sort_keys=False)
+        print(f"  [{i}/{total}] {name}", flush=True)
+
+        if apply_mask and mask_data:
+            try:
+                mask_data(cm, str(filepath))
+            except Exception as e:
+                print(f"Warning: Could not mask {filepath}: {e}")
+        elif apply_mask and not mask_data:
+            print(f"Warning: Masking requested but mask module not available")
+        else:
+            with open(filepath, 'w') as f:
+                yaml.dump(cm, f, default_flow_style=False, sort_keys=False)
 
         created_files.append(str(filepath))
-
-    # Apply masking if requested and mask_resource is available
-    if apply_mask and mask_resource:
-        for file_path in created_files:
-            try:
-                mask_resource(file_path)
-            except Exception as e:
-                print(f"Warning: Could not mask {file_path}: {e}")
-    elif apply_mask and not mask_resource:
-        print("Warning: Masking requested but mask module not available")
 
     return created_files
 

--- a/pyscripts/mask.py
+++ b/pyscripts/mask.py
@@ -292,6 +292,8 @@ class PlaintextMask():
         """
         if isinstance(obj, dict):
             for key, value in obj.items():
+                if key == "binaryData":
+                    continue
                 if isinstance(value, str):
                     # If key name matches sensitive pattern and value is single-line, fully mask
                     # This catches: password: secret123, transport_url: mysql://..., etc.
@@ -335,6 +337,20 @@ def get_resource_kind(path: str) -> Optional[str]:
     except (FileNotFoundError, yaml.YAMLError) as e:
         print(f"Error while reading YAML to determine kind: {e}")
     return None
+
+
+def mask_data(data: Dict[str, Any], path: str) -> bool:
+    """
+    Mask an already-parsed resource dict and write the result to path.
+    Avoids a redundant YAML load when the caller already has the data
+    in memory (e.g. after splitting a ConfigMapList).
+    """
+    if not data:
+        return True
+    m = PlaintextMask(path)
+    m._applyMaskRecursive(data)
+    m._writeYaml(data)
+    return True
 
 
 def mask_resource(path: str, dump_conf: bool = False) -> bool:


### PR DESCRIPTION
When masking is enabled (and it is by default), `cmaps.py` was writing each `ConfigMap` to disk and then `mask_resource()` would `re-read` it, `mask` it, and `write it again`.
This patch optmizes the entire process by passing the in-memory dict to a new `mask_data()` function instead, cutting one `yaml.safe_load` + one `yaml.dump` per `ConfigMap`.

Jira: https://redhat.atlassian.net/browse/OSPCIX-1300