### PR TITLE
Fix concurrency limiter bypass in OMC mode

### DIFF
--- a/collection-scripts/omc.sh
+++ b/collection-scripts/omc.sh
@@ -155,12 +155,12 @@ function collect_omc_inspect {
     local all_crds=()
     mapfile -t all_crds < <(get_matching_crds)
     if [[ ${#all_crds[@]} -gt 0 ]]; then
-        oc adm inspect crd "${all_crds[@]}" --dest-dir="${BASE_COLLECTION_PATH}" &
+        run_bg oc adm inspect crd "${all_crds[@]}" --dest-dir="${BASE_COLLECTION_PATH}"
     fi
     # Collect namespaced resources
     for ns in "${DEFAULT_NAMESPACES[@]}"; do
         if check_namespace "$ns"; then
-            run_bg oc adm inspect -n "$ns" ns/"$ns" --dest-dir="${BASE_COLLECTION_PATH}" &
+            run_bg oc adm inspect -n "$ns" ns/"$ns" --dest-dir="${BASE_COLLECTION_PATH}"
             # Collect subscriptions, CSVs, installplans
             if oc -n "$ns" get subscriptions &>/dev/null; then
                 run_bg oc adm inspect subscriptions -n "$ns" --dest-dir="${BASE_COLLECTION_PATH}"


### PR DESCRIPTION
`CRD` inspect ran with `&` outside `run_bg` wrapper, and `namespace` inspect used `run_bg ... &` which backgrounded the limiter itself. Both bypassed the `CONCURRENCY` cap.