### PR TITLE
Add 18-stable to Renovate baseBranchPatterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,10 @@
     "github>openstack-k8s-operators/renovate-config:default.json5"
   ],
   "baseBranchPatterns": [
-    "main"
+    "main",
+    "18-stable"
   ],
-  "enabledManagers": ["github-actions"]
+  "enabledManagers": [
+    "github-actions"
+  ]
 }


### PR DESCRIPTION
Enable Renovate to process the 18-stable branch alongside main. With useBaseBranchConfig: merge, Renovate uses the 18-stable branch's renovate.json which points to 18-stable.json5 for dependency bounds.